### PR TITLE
Read stdin via os.Stdin instead of /dev/stdin to avoid permission error.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -212,16 +212,22 @@ func (c *CLI) uploadSnippet(ctx context.Context, filename, uploadFilename, filet
 		return fmt.Errorf("must specify channel for uploading to snippet")
 	}
 
+	var reader io.ReadCloser
 	if filename == "" {
-		filename = "/dev/stdin"
+		reader = os.Stdin
+	} else {
+		_, err := os.Stat(filename)
+		if err != nil {
+			return xerrors.Errorf("%s does not exist: %w", filename, err)
+		}
+		reader, err = os.Open(filename)
+		if err != nil {
+			return xerrors.Errorf("can't open %s: %w", filename, err)
+		}
 	}
+	defer reader.Close()
 
-	_, err := os.Stat(filename)
-	if err != nil {
-		return xerrors.Errorf("%s does not exist: %w", filename, err)
-	}
-
-	content, err := ioutil.ReadFile(filename)
+	content, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When notify_slack runs as non-root user A and it reads stdin from another non-root user, it fails with permission denied error.

```
$ id -un
nonroot1
$ ps aux | sudo -u nonroot2 notify_slack -snippet
open /dev/stdin: permission denied
```

This is probably because `nonroot2` user does not have read right for the pipe. (Sorry I couldn't find documentation about this behavior)

```
$ echo hello | sudo -u nonroot2 bash -c 'ls -l /dev/stdin; ls -l /proc/self/fd/0"'
lrwxrwxrwx 1 root root 15 May 17 15:03 /dev/stdin -> /proc/self/fd/0
lr-x------ 1 nonroot2 nogroup 64 Jul  3 17:47 /proc/self/fd/0 -> 'pipe:[164455751]'
```

This patch fixes this error because `os.Stdin` is just fd 0.