### PR TITLE
refactor exec.Start() and don't provide context for callback

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.15.x' ]
+        go: [ '1.15.x', '1.16.x' ]
     steps:
 
     - name: Set up Go

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -198,7 +198,10 @@ func (c *CLI) Run(args []string) int {
 
 	doneCallback := func(output string) error {
 		defer func() {
-			done <- struct{}{}
+			// If goroutine is not used, it will not exit when the pipe is closed
+			go func() {
+				done <- struct{}{}
+			}()
 		}()
 
 		return flushCallback(output)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -175,8 +175,8 @@ func (c *CLI) Run(args []string) int {
 
 	ex := throttle.NewExec(copyStdin)
 
-	exitC := make(chan os.Signal, 1)
-	signal.Notify(exitC, syscall.SIGTERM, syscall.SIGINT)
+	sigC := make(chan os.Signal, 1)
+	signal.Notify(sigC, syscall.SIGTERM, syscall.SIGINT)
 
 	channel := c.conf.PrimaryChannel
 	if channel == "" {
@@ -189,19 +189,19 @@ func (c *CLI) Run(args []string) int {
 		IconEmoji: c.conf.IconEmoji,
 	}
 
-	flushCallback := func(_ context.Context, output string) error {
+	flushCallback := func(output string) error {
 		param.Text = output
 		return c.sClient.PostText(context.Background(), param)
 	}
 
 	done := make(chan struct{})
 
-	doneCallback := func(ctx context.Context, output string) error {
+	doneCallback := func(output string) error {
 		defer func() {
 			done <- struct{}{}
 		}()
 
-		return flushCallback(ctx, output)
+		return flushCallback(output)
 	}
 
 	ticker := time.NewTicker(c.conf.Duration)
@@ -209,11 +209,15 @@ func (c *CLI) Run(args []string) int {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	ex.Start(ctx, ticker.C, flushCallback, doneCallback)
+	exitC := make(chan struct{})
+	go func() {
+		ex.Start(ctx, ticker.C, flushCallback, doneCallback)
+		close(exitC)
+	}()
 
 	select {
+	case <-sigC:
 	case <-exitC:
-	case <-ex.Wait():
 	}
 	cancel()
 

--- a/throttle/exec_test.go
+++ b/throttle/exec_test.go
@@ -101,3 +101,95 @@ func TestRun_pipeClose(t *testing.T) {
 		t.Errorf("It will be written %q; but %q", expected, b)
 	}
 }
+
+func TestRun_contextDone(t *testing.T) {
+	pr, pw := io.Pipe()
+
+	output := new(bytes.Buffer)
+
+	ex := NewExec(pr)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	testC := make(chan time.Time)
+	count := 0
+	fc := make(chan struct{})
+
+	flushCallback := func(s string) error {
+		defer func() {
+			fc <- struct{}{}
+			// to random fail from Go 1.12 or later
+			time.Sleep(2 * time.Millisecond)
+		}()
+
+		count++
+
+		output.WriteString(s)
+
+		return nil
+	}
+
+	doneCount := 0
+
+	doneCallback := func(s string) error {
+		defer func() {
+			go func() {
+				fc <- struct{}{}
+			}()
+		}()
+
+		doneCount++
+
+		output.WriteString(s)
+
+		return nil
+	}
+
+	exitC := make(chan struct{})
+	go func() {
+		ex.Start(ctx, testC, flushCallback, doneCallback)
+		close(exitC)
+	}()
+
+	testC <- time.Time{}
+	<-fc
+
+	if count != 1 {
+		t.Error("the flushCallback function has not been called")
+	}
+
+	expected := []byte("abcd\nefgh\n")
+	pw.Write(expected)
+
+	if b := output.Bytes(); b != nil {
+		t.Errorf("will not be written if it is not flushed %s", b)
+	}
+
+	testC <- time.Time{}
+	<-fc
+
+	if count != 2 {
+		t.Errorf("the flushCallback function has not been called")
+	}
+
+	if b := output.Bytes(); !bytes.Equal(b, expected) {
+		t.Errorf("It will be written %q; but %q", expected, b)
+	}
+
+	output.Reset()
+
+	expected = []byte("ijk\nlmn\n")
+	pw.Write(expected)
+
+	cancel()
+	<-exitC
+
+	<-fc
+
+	if doneCount != 1 {
+		t.Errorf("the doneCallback function has not been called")
+	}
+
+	if b := output.Bytes(); !bytes.Equal(b, expected) {
+		t.Errorf("It will be written %q; but %q", expected, b)
+	}
+}

--- a/throttle/exec_test.go
+++ b/throttle/exec_test.go
@@ -38,6 +38,7 @@ func TestRun_pipeClose(t *testing.T) {
 
 	doneCallback := func(s string) error {
 		defer func() {
+			// If goroutine is not used, tests cannot be run multiple times
 			go func() {
 				fc <- struct{}{}
 			}()
@@ -132,6 +133,7 @@ func TestRun_contextDone(t *testing.T) {
 
 	doneCallback := func(s string) error {
 		defer func() {
+			// If goroutine is not used, tests cannot be run multiple times
 			go func() {
 				fc <- struct{}{}
 			}()

--- a/throttle/exec_test.go
+++ b/throttle/exec_test.go
@@ -38,7 +38,9 @@ func TestRun_pipeClose(t *testing.T) {
 
 	doneCallback := func(s string) error {
 		defer func() {
-			fc <- struct{}{}
+			go func() {
+				fc <- struct{}{}
+			}()
 		}()
 
 		doneCount++


### PR DESCRIPTION
make exec.Start() functions synchronous
callback functions should not be killed by context