### PR TITLE
[nits] close response body

### DIFF
--- a/slack/client.go
+++ b/slack/client.go
@@ -113,6 +113,7 @@ func (c *Client) PostText(ctx context.Context, param *PostTextParam) error {
 	if err != nil {
 		return err
 	}
+	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		b, err := io.ReadAll(res.Body)
@@ -161,6 +162,7 @@ func (c *Client) PostFile(ctx context.Context, token string, param *PostFilePara
 	if err != nil {
 		return err
 	}
+	defer res.Body.Close()
 
 	b, err := io.ReadAll(res.Body)
 	if err != nil {


### PR DESCRIPTION
The slack client response body did not seem to be closed.
please take it in, If you don't mind.

I'm going to use at ISUCON12. Thank you for your software.