### PR TITLE
Change: Give WithoutCancel context for Slack request

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -174,14 +174,14 @@ func (c *CLI) Run(args []string) int {
 		IconEmoji: c.conf.IconEmoji,
 	}
 
-	flushCallback := func(output string) error {
+	flushCallback := func(ctx context.Context, output string) error {
 		param.Text = output
-		return c.sClient.PostText(context.Background(), param)
+		return c.sClient.PostText(context.WithoutCancel(ctx), param)
 	}
 
 	done := make(chan struct{})
 
-	doneCallback := func(output string) error {
+	doneCallback := func(ctx context.Context, output string) error {
 		defer func() {
 			// If goroutine is not used, it will not exit when the pipe is closed
 			go func() {
@@ -189,7 +189,7 @@ func (c *CLI) Run(args []string) int {
 			}()
 		}()
 
-		return flushCallback(output)
+		return flushCallback(context.WithoutCancel(ctx), output)
 	}
 
 	ticker := time.NewTicker(c.conf.Duration)

--- a/throttle/exec.go
+++ b/throttle/exec.go
@@ -51,7 +51,7 @@ func (ex *Exec) stringAndReset() string {
 	return ex.writer.String()
 }
 
-func (ex *Exec) Start(ctx context.Context, interval <-chan time.Time, flushCallback func(output string) error, doneCallback func(output string) error) {
+func (ex *Exec) Start(ctx context.Context, interval <-chan time.Time, flushCallback func(ctx context.Context, output string) error, doneCallback func(ctx context.Context, output string) error) {
 	go func() {
 		for {
 			line, _, err := ex.reader.ReadLine()
@@ -79,12 +79,12 @@ L:
 	for {
 		select {
 		case <-interval:
-			flushCallback(ex.flush())
+			flushCallback(ctx, ex.flush())
 		case <-ctx.Done():
-			doneCallback(ex.flush())
+			doneCallback(ctx, ex.flush())
 			break L
 		case <-ex.Wait():
-			doneCallback(ex.flush())
+			doneCallback(ctx, ex.flush())
 			break L
 		}
 	}

--- a/throttle/exec_test.go
+++ b/throttle/exec_test.go
@@ -20,7 +20,7 @@ func TestRun_pipeClose(t *testing.T) {
 	count := 0
 	fc := make(chan struct{})
 
-	flushCallback := func(s string) error {
+	flushCallback := func(ctx context.Context, s string) error {
 		defer func() {
 			fc <- struct{}{}
 			// to random fail from Go 1.12 or later
@@ -36,7 +36,7 @@ func TestRun_pipeClose(t *testing.T) {
 
 	doneCount := 0
 
-	doneCallback := func(s string) error {
+	doneCallback := func(ctx context.Context, s string) error {
 		defer func() {
 			// If goroutine is not used, tests cannot be run multiple times
 			go func() {
@@ -115,7 +115,7 @@ func TestRun_contextDone(t *testing.T) {
 	count := 0
 	fc := make(chan struct{})
 
-	flushCallback := func(s string) error {
+	flushCallback := func(ctx context.Context, s string) error {
 		defer func() {
 			fc <- struct{}{}
 			// to random fail from Go 1.12 or later
@@ -131,7 +131,7 @@ func TestRun_contextDone(t *testing.T) {
 
 	doneCount := 0
 
-	doneCallback := func(s string) error {
+	doneCallback := func(ctx context.Context, s string) error {
 		defer func() {
 			// If goroutine is not used, tests cannot be run multiple times
 			go func() {


### PR DESCRIPTION
Before, no context for Slack because we want it to run even if cancel. Now, I give WithoutCancel context clearly.