### PR TITLE
Update Go versions to 1.22.x in workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.21.x"]
+        go: ["1.22.x"]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes changes to the Go version and the GoReleaser arguments in the GitHub workflow files. The Go version has been updated from 1.21.x to 1.22.x in both the `go.yml` and `release.yml` files. The arguments for the GoReleaser action have also been modified in the `release.yml` file.

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL9-R9): Updated the Go version in the matrix from 1.21.x to 1.22.x.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L15-R20): Updated the Go version from 1.21.x to 1.22.x and changed the GoReleaser arguments from `release --rm-dist` to `release --clean`.