### PR TITLE
Add cover target to run tests with coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,11 @@ errcheck:
 staticcheck:
 	staticcheck -checks="all,-ST1000" ./...
 
+.PHONY: cover
+cover:
+	go test -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out
+
 .PHONY: clean
 clean:
 	rm -rf bin/*


### PR DESCRIPTION
This pull request includes changes to the `Makefile` to improve code coverage reporting. A new `cover` target has been added to the `Makefile` which generates a coverage report and opens it in a browser.

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R29-R33): Added a `cover` target to the `Makefile` that runs tests with coverage and then uses `go tool cover` to generate and display an HTML coverage report.