### PR TITLE
Add debug mode with slog for logging

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/signal"
 	"runtime"
@@ -60,6 +61,7 @@ func (c *CLI) Run(args []string) int {
 		uploadFilename string
 		filetype       string
 		snippetMode    bool
+		debugMode      bool
 	)
 
 	c.conf = config.NewConfig()
@@ -78,6 +80,8 @@ func (c *CLI) Run(args []string) int {
 	flags.StringVar(&filetype, "filetype", "", "specify a filetype (for uploading to snippet)")
 
 	flags.BoolVar(&snippetMode, "snippet", false, "switch to snippet uploading mode")
+
+	flags.BoolVar(&debugMode, "debug", false, "debug mode (for developers)")
 
 	flags.BoolVar(&version, "version", false, "Print version information and quit")
 
@@ -128,8 +132,15 @@ func (c *CLI) Run(args []string) int {
 		return ExitCodeFail
 	}
 
+	var logger *slog.Logger
+	if debugMode {
+		logger = slog.New(slog.NewTextHandler(c.errStream, &slog.HandlerOptions{AddSource: true, Level: slog.LevelDebug}))
+	} else {
+		logger = slog.New(slog.NewTextHandler(c.errStream, nil))
+	}
+
 	if filename != "" || snippetMode {
-		c.sClient, err = slack.NewClientForPostFile(nil)
+		c.sClient, err = slack.NewClientForPostFile(logger)
 		if err != nil {
 			fmt.Fprintln(c.errStream, err)
 			return ExitCodeFail
@@ -154,7 +165,7 @@ func (c *CLI) Run(args []string) int {
 		return ExitCodeFail
 	}
 
-	c.sClient, err = slack.NewClient(c.conf.SlackURL, nil)
+	c.sClient, err = slack.NewClient(c.conf.SlackURL, logger)
 	if err != nil {
 		fmt.Fprintln(c.errStream, err)
 		return ExitCodeFail

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -15,7 +16,7 @@ import (
 )
 
 func TestNewClient_badURL(t *testing.T) {
-	_, err := NewClient("", nil)
+	_, err := NewClient("", slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err == nil {
 		t.Fatal("expected error, but nothing was returned")
 	}
@@ -27,7 +28,7 @@ func TestNewClient_badURL(t *testing.T) {
 }
 
 func TestNewClient_parsesURL(t *testing.T) {
-	client, err := NewClient("https://example.com/foo/bar", nil)
+	client, err := NewClient("https://example.com/foo/bar", slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +81,7 @@ func TestPostText_Success(t *testing.T) {
 		http.ServeFile(w, r, "testdata/post_text_ok.html")
 	})
 
-	c, err := NewClient(testAPIServer.URL, nil)
+	c, err := NewClient(testAPIServer.URL, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +110,7 @@ func TestPostText_Fail(t *testing.T) {
 		http.ServeFile(w, r, "testdata/post_text_fail.html")
 	})
 
-	c, err := NewClient(testAPIServer.URL, nil)
+	c, err := NewClient(testAPIServer.URL, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,7 +173,7 @@ func TestPostFile_Success(t *testing.T) {
 
 	defer SetSlackFilesUploadURL(testAPIServer.URL)()
 
-	c, err := NewClientForPostFile(nil)
+	c, err := NewClientForPostFile(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -232,7 +233,7 @@ func TestPostFile_Success_provideFiletype(t *testing.T) {
 
 	defer SetSlackFilesUploadURL(testAPIServer.URL)()
 
-	c, err := NewClientForPostFile(nil)
+	c, err := NewClientForPostFile(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,7 +264,7 @@ func TestPostFile_FailNotOk(t *testing.T) {
 
 	defer SetSlackFilesUploadURL(testAPIServer.URL)()
 
-	c, err := NewClientForPostFile(nil)
+	c, err := NewClientForPostFile(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -300,7 +301,7 @@ func TestPostFile_FailNotResponseStatusCodeNotOK(t *testing.T) {
 
 	defer SetSlackFilesUploadURL(testAPIServer.URL)()
 
-	c, err := NewClientForPostFile(nil)
+	c, err := NewClientForPostFile(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -336,7 +337,7 @@ func TestPostFile_FailNotJSON(t *testing.T) {
 
 	defer SetSlackFilesUploadURL(testAPIServer.URL)()
 
-	c, err := NewClientForPostFile(nil)
+	c, err := NewClientForPostFile(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This pull request introduces changes to the `internal/cli/cli.go`, `internal/slack/client.go`, and `internal/slack/client_test.go` files. The major changes include the addition of a debug mode in the CLI, switching from the standard log package to the structured log package (slog), and updating the tests to reflect these changes.

Changes to the CLI (`internal/cli/cli.go`):

* Imported the `log/slog` package for structured logging.
* Added a `debugMode` boolean variable to the `Run` function. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR64) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR84-R85)
* Created a new `slog.Logger` instance based on the `debugMode` variable.
* Updated the `NewClientForPostFile` and `NewClient` functions to pass the `logger` instance.

Changes to the Slack client (`internal/slack/client.go`):

* Replaced the standard `log` package with the `log/slog` package.
* Replaced the `Logger` field in the `Client` struct with a `slog.Logger` instance.
* Updated the `NewClient` and `NewClientForPostFile` functions to accept a `slog.Logger` instance. [[1]](diffhunk://#diff-69d905aaedc394ec3fefc19952f55b4dbb610cf13c2578dc067820ba9cf05b73L47-R47) [[2]](diffhunk://#diff-69d905aaedc394ec3fefc19952f55b4dbb610cf13c2578dc067820ba9cf05b73L71-R66)
* Removed the creation of a discard logger in the `NewClient` and `NewClientForPostFile` functions.
* Added debug logs to the `PostText` and `PostFile` functions. [[1]](diffhunk://#diff-69d905aaedc394ec3fefc19952f55b4dbb610cf13c2578dc067820ba9cf05b73R102-R118) [[2]](diffhunk://#diff-69d905aaedc394ec3fefc19952f55b4dbb610cf13c2578dc067820ba9cf05b73R167-R168)

Changes to the Slack client tests (`internal/slack/client_test.go`):

* Imported the `log/slog` package.
* Updated all test functions to create a new `slog.Logger` instance and pass it to the `NewClient` and `NewClientForPostFile` functions. [[1]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL18-R19) [[2]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL30-R31) [[3]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL83-R84) [[4]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL112-R113) [[5]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL175-R176) [[6]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL235-R236) [[7]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL266-R267) [[8]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL303-R304) [[9]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL339-R340)