### PR TITLE
Refactor slack token validation and usage in CLI and Slack client

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -140,14 +140,14 @@ func (c *CLI) Run(args []string) int {
 	}
 
 	if filename != "" || snippetMode {
-		c.sClient, err = slack.NewClientForPostFile(logger)
-		if err != nil {
-			fmt.Fprintln(c.errStream, err)
+		if c.conf.Token == "" {
+			fmt.Fprintln(c.errStream, "must specify Slack token for uploading to snippet")
 			return ExitCodeFail
 		}
 
-		if c.conf.Token == "" {
-			fmt.Fprintln(c.errStream, "must specify Slack token for uploading to snippet")
+		c.sClient, err = slack.NewClientForPostFile(c.conf.Token, logger)
+		if err != nil {
+			fmt.Fprintln(c.errStream, err)
 			return ExitCodeFail
 		}
 
@@ -259,7 +259,7 @@ func (c *CLI) uploadSnippet(ctx context.Context, filename, uploadFilename, filet
 		Content:  string(content),
 		Filetype: filetype,
 	}
-	err = c.sClient.PostFile(ctx, c.conf.Token, param)
+	err = c.sClient.PostFile(ctx, param)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -14,11 +14,11 @@ import (
 type fakeSlackClient struct {
 	slack.Slack
 
-	FakePostFile func(ctx context.Context, token string, param *slack.PostFileParam) error
+	FakePostFile func(ctx context.Context, param *slack.PostFileParam) error
 }
 
-func (c *fakeSlackClient) PostFile(ctx context.Context, token string, param *slack.PostFileParam) error {
-	return c.FakePostFile(ctx, token, param)
+func (c *fakeSlackClient) PostFile(ctx context.Context, param *slack.PostFileParam) error {
+	return c.FakePostFile(ctx, param)
 }
 
 func (c *fakeSlackClient) PostText(ctx context.Context, param *slack.PostTextParam) error {
@@ -62,7 +62,7 @@ func TestUploadSnippet(t *testing.T) {
 	}
 
 	cl.sClient = &fakeSlackClient{
-		FakePostFile: func(ctx context.Context, token string, param *slack.PostFileParam) error {
+		FakePostFile: func(ctx context.Context, param *slack.PostFileParam) error {
 			if param.Channel != cl.conf.Channel {
 				t.Errorf("expected %s; got %s", cl.conf.Channel, param.Channel)
 			}
@@ -87,7 +87,7 @@ func TestUploadSnippet(t *testing.T) {
 	}
 
 	cl.sClient = &fakeSlackClient{
-		FakePostFile: func(ctx context.Context, token string, param *slack.PostFileParam) error {
+		FakePostFile: func(ctx context.Context, param *slack.PostFileParam) error {
 			if param.Channel != cl.conf.Channel {
 				t.Errorf("expected %s; got %s", cl.conf.Channel, param.Channel)
 			}
@@ -112,7 +112,7 @@ func TestUploadSnippet(t *testing.T) {
 	}
 
 	cl.sClient = &fakeSlackClient{
-		FakePostFile: func(ctx context.Context, token string, param *slack.PostFileParam) error {
+		FakePostFile: func(ctx context.Context, param *slack.PostFileParam) error {
 			if param.Channel != cl.conf.Channel {
 				t.Errorf("expected %s; got %s", cl.conf.Channel, param.Channel)
 			}
@@ -144,7 +144,7 @@ func TestUploadSnippet(t *testing.T) {
 	cl.conf.SnippetChannel = "snippet_channel"
 
 	cl.sClient = &fakeSlackClient{
-		FakePostFile: func(ctx context.Context, token string, param *slack.PostFileParam) error {
+		FakePostFile: func(ctx context.Context, param *slack.PostFileParam) error {
 			if param.Channel != cl.conf.SnippetChannel {
 				t.Errorf("expected %s; got %s", cl.conf.SnippetChannel, param.Channel)
 			}
@@ -171,7 +171,7 @@ func TestUploadSnippet(t *testing.T) {
 	cl.conf.PrimaryChannel = "primary_channel"
 
 	cl.sClient = &fakeSlackClient{
-		FakePostFile: func(ctx context.Context, token string, param *slack.PostFileParam) error {
+		FakePostFile: func(ctx context.Context, param *slack.PostFileParam) error {
 			if param.Channel != cl.conf.PrimaryChannel {
 				t.Errorf("expected %s; got %s", cl.conf.PrimaryChannel, param.Channel)
 			}

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -173,12 +173,12 @@ func TestPostFile_Success(t *testing.T) {
 
 	defer SetSlackFilesUploadURL(testAPIServer.URL)()
 
-	c, err := NewClientForPostFile(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c, err := NewClientForPostFile(slackToken, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = c.PostFile(context.Background(), slackToken, param)
+	err = c.PostFile(context.Background(), param)
 
 	if err != nil {
 		t.Fatal(err)
@@ -233,12 +233,12 @@ func TestPostFile_Success_provideFiletype(t *testing.T) {
 
 	defer SetSlackFilesUploadURL(testAPIServer.URL)()
 
-	c, err := NewClientForPostFile(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c, err := NewClientForPostFile(slackToken, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = c.PostFile(context.Background(), slackToken, param)
+	err = c.PostFile(context.Background(), param)
 
 	if err != nil {
 		t.Fatal(err)
@@ -264,12 +264,12 @@ func TestPostFile_FailNotOk(t *testing.T) {
 
 	defer SetSlackFilesUploadURL(testAPIServer.URL)()
 
-	c, err := NewClientForPostFile(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c, err := NewClientForPostFile(slackToken, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = c.PostFile(context.Background(), slackToken, param)
+	err = c.PostFile(context.Background(), param)
 
 	if err == nil {
 		t.Fatal("expected error, but nothing was returned")
@@ -301,12 +301,12 @@ func TestPostFile_FailNotResponseStatusCodeNotOK(t *testing.T) {
 
 	defer SetSlackFilesUploadURL(testAPIServer.URL)()
 
-	c, err := NewClientForPostFile(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c, err := NewClientForPostFile(slackToken, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = c.PostFile(context.Background(), slackToken, param)
+	err = c.PostFile(context.Background(), param)
 
 	if err == nil {
 		t.Fatal("expected error, but nothing was returned")
@@ -337,12 +337,12 @@ func TestPostFile_FailNotJSON(t *testing.T) {
 
 	defer SetSlackFilesUploadURL(testAPIServer.URL)()
 
-	c, err := NewClientForPostFile(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c, err := NewClientForPostFile(slackToken, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = c.PostFile(context.Background(), slackToken, param)
+	err = c.PostFile(context.Background(), param)
 
 	if err == nil {
 		t.Fatal("expected error, but nothing was returned")


### PR DESCRIPTION
This pull request primarily focuses on refactoring the handling of Slack tokens in the codebase, specifically in the `internal/cli/cli.go`, `internal/cli/cli_test.go`, `internal/slack/client.go`, and `internal/slack/client_test.go` files. The changes include moving the Slack token from function parameters to a field in the `Client` struct, and adjusting all related function calls and tests to match this new structure.

Changes to Slack token handling:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL143-R150): The Slack token is now checked before creating a new Slack client, and the client is created with the token as a parameter. The token is no longer passed as a parameter to the `PostFile` method. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL143-R150) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL262-R262)
* [`internal/cli/cli_test.go`](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL17-R21): Adjusted all test cases to match the new structure where the token is not passed as a parameter to the `PostFile` method. [[1]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL17-R21) [[2]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL65-R65) [[3]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL90-R90) [[4]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL115-R115) [[5]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL147-R147) [[6]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL174-R174)
* [`internal/slack/client.go`](diffhunk://#diff-69d905aaedc394ec3fefc19952f55b4dbb610cf13c2578dc067820ba9cf05b73R25-R26): Added a `Token` field to the `Client` struct. Adjusted the `NewClientForPostFile` function to take a token as a parameter and assign it to the new client. The `PostFile` method no longer takes a token as a parameter, and instead uses the token from the `Client` struct. [[1]](diffhunk://#diff-69d905aaedc394ec3fefc19952f55b4dbb610cf13c2578dc067820ba9cf05b73R25-R26) [[2]](diffhunk://#diff-69d905aaedc394ec3fefc19952f55b4dbb610cf13c2578dc067820ba9cf05b73L44-R46) [[3]](diffhunk://#diff-69d905aaedc394ec3fefc19952f55b4dbb610cf13c2578dc067820ba9cf05b73L66-R75) [[4]](diffhunk://#diff-69d905aaedc394ec3fefc19952f55b4dbb610cf13c2578dc067820ba9cf05b73L128-R141)
* [`internal/slack/client_test.go`](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL176-R181): Adjusted all test cases to match the new structure where the token is not passed as a parameter to the `PostFile` method. [[1]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL176-R181) [[2]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL236-R241) [[3]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL267-R272) [[4]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL304-R309) [[5]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL340-R345)