### PR TITLE
use new api for uploading file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## [v0.5.0] - 
+
+### Breaking Changes
+
+- **API Deprecation**: As per [Slack's latest API update](https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay), `files.upload` is now deprecated. We have updated our tool to use the new APIs, `files.getUploadURLExternal` and `files.completeUploadExternal`.
+- **Channel Specification**: It is no longer possible to specify a `channel` for file uploads. You must now use `channel-id`.
+- **Filetype Option Update**: The `-filetype` option has been modified. Please use `-snippet-type` instead for specifying the type of file when uploading to a snippet.
+
+### Changed
+
+* update Go version
+* update dependent libraries
+* update README
+
 ## [v0.4.14] - 2023-09-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ The Slack API allows you to specify the filetype of a file when posting it as a 
       config file name
 -channel string
       specify channel (unavailable for new Incoming Webhooks)
+-channel-id string
+      specify channel id (for uploading a file)
+-debug
+      debug mode (for developers)
 -filename string
       specify a file name (for uploading to snippet)
 -filetype string
@@ -92,6 +96,7 @@ The toml file contains the following information.
 url = "https://hooks.slack.com/services/**"
 token = "xoxp-xxxxx"
 channel = "#general"
+channel_id = "C12345678"
 username = "tester"
 icon_emoji = ":rocket:"
 interval = "1s"
@@ -149,7 +154,7 @@ Some settings for the Slack API can be provided using environment variables.
 NOTIFY_SLACK_WEBHOOK_URL
 NOTIFY_SLACK_TOKEN
 NOTIFY_SLACK_CHANNEL
-NOTIFY_SLACK_SNIPPET_CHANNEL
+NOTIFY_SLACK_CHANNEL_ID
 NOTIFY_SLACK_USERNAME
 NOTIFY_SLACK_ICON_EMOJI
 NOTIFY_SLACK_INTERVAL

--- a/README.md
+++ b/README.md
@@ -108,13 +108,10 @@ Note:
     * You can use the following options to customize your message when posting to Slack as text: `channel`, `username`, `icon_emoji`, and `interval`.
     * Due to a recent change in the specification for Incoming Webhooks, it is currently not possible to override the `channel`, `username`, and `icon_emoji` options when posting to Slack. For more information, please refer to [this resource](https://api.slack.com/messaging/webhooks#advanced_message_formatting)
     * You can create an Incoming Webhooks URL at https://slack.com/services/new/incoming-webhook
-  * To post a file as a snippet to Slack, you will need to provide both a `token` and a `channel`.
+  * To post a file as a snippet to Slack, you will need to provide both a `token` and a `channel_id`.
     * The `username` and `icon_emoji` options will be ignored when posting a file as a snippet to Slack.
     * For instructions on how to create a token, please see the next section.
-
-Tips:
-
-  * If you want to use a different default channel for snippets, you can specify it using the `snippet_channel` option.
+    * You cannot specify a channel because the slack api support only the channel_id.
 
 ### How to create a token
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The Slack API allows you to specify the filetype of a file when posting it as a 
 -filename string
       specify a file name (for uploading to snippet)
 -filetype string
-      specify a filetype (for uploading to snippet)
+      [compatible] specify a filetype for uploading to snippet. This option is maintained for compatibility. Please use -snippet-type instead.
 -icon-emoji string
       specify icon emoji (unavailable for new Incoming Webhooks)
 -interval duration
@@ -72,6 +72,8 @@ The Slack API allows you to specify the filetype of a file when posting it as a 
       slack url (Incoming Webhooks URL)
 -snippet
       switch to snippet uploading mode
+-snippet-type string
+      specify a snippet_type (for uploading to snippet)
 -token string
       token (for uploading to snippet)
 -username string
@@ -111,7 +113,9 @@ Note:
   * To post a file as a snippet to Slack, you will need to provide both a `token` and a `channel_id`.
     * The `username` and `icon_emoji` options will be ignored when posting a file as a snippet to Slack.
     * For instructions on how to create a token, please see the next section.
-    * You cannot specify a channel because the slack api support only the channel_id.
+    * You cannot specify a channel because the slack api support only the `channel_id`.
+    * If you don't specify `channel_id`, the file will be private. So, if you need to post a file public, you must specify `channel_id`.
+    * The Slack API can cause delays, so posting might take longer.
 
 ### How to create a token
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -69,7 +69,8 @@ func (c *CLI) Run(args []string) int {
 	flags := flag.NewFlagSet("notify_slack", flag.ContinueOnError)
 	flags.SetOutput(c.errStream)
 
-	flags.StringVar(&c.conf.PrimaryChannel, "channel", "", "specify channel (unavailable for new Incoming Webhooks)")
+	flags.StringVar(&c.conf.Channel, "channel", "", "specify channel (unavailable for new Incoming Webhooks)")
+	flags.StringVar(&c.conf.ChannelID, "channel-id", "", "specify channel id (for uploading a file)")
 	flags.StringVar(&c.conf.SlackURL, "slack-url", "", "slack url (Incoming Webhooks URL)")
 	flags.StringVar(&c.conf.Token, "token", "", "token (for uploading to snippet)")
 	flags.StringVar(&c.conf.Username, "username", "", "specify username (unavailable for new Incoming Webhooks)")
@@ -178,10 +179,7 @@ func (c *CLI) Run(args []string) int {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
-	channel := c.conf.PrimaryChannel
-	if channel == "" {
-		channel = c.conf.Channel
-	}
+	channel := c.conf.Channel
 
 	param := &slack.PostTextParam{
 		Channel:   channel,
@@ -216,18 +214,8 @@ func (c *CLI) Run(args []string) int {
 	return ExitCodeOK
 }
 
-func (c *CLI) uploadSnippet(ctx context.Context, filename, uploadFilename, filetype string) error {
-	channel := c.conf.PrimaryChannel
-	if channel == "" {
-		channel = c.conf.SnippetChannel
-	}
-	if channel == "" {
-		channel = c.conf.Channel
-	}
-
-	if channel == "" {
-		return fmt.Errorf("must specify channel for uploading to snippet")
-	}
+func (c *CLI) uploadSnippet(ctx context.Context, filename, uploadFilename, snippetType string) error {
+	channelID := c.conf.ChannelID
 
 	var reader io.ReadCloser
 	if filename == "" {
@@ -254,12 +242,12 @@ func (c *CLI) uploadSnippet(ctx context.Context, filename, uploadFilename, filet
 	}
 
 	param := &slack.PostFileParam{
-		Channel:  channel,
-		Filename: uploadFilename,
-		Content:  string(content),
-		Filetype: filetype,
+		ChannelID:   channelID,
+		Filename:    uploadFilename,
+		SnippetType: snippetType,
 	}
-	err = c.sClient.PostFile(ctx, param)
+
+	err = c.sClient.PostFile(ctx, param, content)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -78,7 +78,8 @@ func (c *CLI) Run(args []string) int {
 	flags.DurationVar(&c.conf.Duration, "interval", time.Second, "interval")
 	flags.StringVar(&tomlFile, "c", "", "config file name")
 	flags.StringVar(&uploadFilename, "filename", "", "specify a file name (for uploading to snippet)")
-	flags.StringVar(&filetype, "filetype", "", "specify a filetype (for uploading to snippet)")
+	flags.StringVar(&filetype, "filetype", "", "[compatible] specify a filetype for uploading to snippet. This option is maintained for compatibility. Please use -snippet-type instead.")
+	flags.StringVar(&filetype, "snippet-type", "", "specify a snippet_type (for uploading to snippet)")
 
 	flags.BoolVar(&snippetMode, "snippet", false, "switch to snippet uploading mode")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,9 +16,9 @@ var (
 type Config struct {
 	SlackURL       string
 	Token          string
-	PrimaryChannel string
 	Channel        string
 	SnippetChannel string
+	ChannelID      string
 	Username       string
 	IconEmoji      string
 	Duration       time.Duration
@@ -42,7 +42,13 @@ func (c *Config) LoadEnv() error {
 	}
 
 	if c.SnippetChannel == "" {
-		c.SnippetChannel = os.Getenv("NOTIFY_SLACK_SNIPPET_CHANNEL")
+		if os.Getenv("NOTIFY_SLACK_SNIPPET_CHANNEL") != "" {
+			return fmt.Errorf("the NOTIFY_SLACK_SNIPPET_CHANNEL option is deprecated")
+		}
+	}
+
+	if c.ChannelID == "" {
+		c.ChannelID = os.Getenv("NOTIFY_SLACK_CHANNEL_ID")
 	}
 
 	if c.Username == "" {
@@ -70,6 +76,7 @@ type slackConfig struct {
 	Token          string
 	Channel        string
 	SnippetChannel string `toml:"snippet_channel"`
+	ChannelID      string `toml:"channel_id"`
 	Username       string
 	IconEmoji      string `toml:"icon_emoji"`
 	Interval       string
@@ -109,14 +116,17 @@ func (c *Config) LoadTOML(filename string) error {
 			c.Channel = slackConfig.Channel
 		}
 	}
-	if c.SnippetChannel == "" {
-		if slackConfig.SnippetChannel != "" {
-			c.SnippetChannel = slackConfig.SnippetChannel
-		}
-	}
 	if c.Username == "" {
 		if slackConfig.Username != "" {
 			c.Username = slackConfig.Username
+		}
+	}
+	if slackConfig.SnippetChannel != "" {
+		return fmt.Errorf("the snippet_channel option is deprecated")
+	}
+	if c.ChannelID == "" {
+		if slackConfig.ChannelID != "" {
+			c.ChannelID = slackConfig.ChannelID
 		}
 	}
 	if c.IconEmoji == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,9 +28,9 @@ func TestLoadTOML(t *testing.T) {
 	if c.Channel != expectedChannel {
 		t.Errorf("got %s, want %s", c.Channel, expectedChannel)
 	}
-	expectedSnippetChannel := "#general"
-	if c.SnippetChannel != expectedSnippetChannel {
-		t.Errorf("got %s, want %s", c.SnippetChannel, expectedSnippetChannel)
+	expectedChannelID := "C12345678"
+	if c.ChannelID != expectedChannelID {
+		t.Errorf("got %s, want %s", c.ChannelID, expectedChannelID)
 	}
 	expectedUsername := "deploy!"
 	if c.Username != expectedUsername {
@@ -45,11 +46,24 @@ func TestLoadTOML(t *testing.T) {
 	}
 }
 
+func TestLoadTOML_Deprecated(t *testing.T) {
+	c := NewConfig()
+	err := c.LoadTOML("./testdata/config_deprecated.toml")
+	if err == nil {
+		t.Fatal("expected error, but got nil")
+	}
+
+	expected := "the snippet_channel option is deprecated"
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("got %s, want %s", err.Error(), expected)
+	}
+}
+
 func TestLoadEnv(t *testing.T) {
 	expectedSlackURL := "https://hooks.slack.com/aaaaa"
 	expectedToken := "xoxp-token"
 	expectedChannel := "#test"
-	expectedSnippetChannel := "#general"
+	expectedChannelID := "C12345678"
 	expectedUsername := "deploy!"
 	expectedIconEmoji := ":rocket:"
 	expectedIntervalStr := "2s"
@@ -58,7 +72,7 @@ func TestLoadEnv(t *testing.T) {
 	t.Setenv("NOTIFY_SLACK_WEBHOOK_URL", expectedSlackURL)
 	t.Setenv("NOTIFY_SLACK_TOKEN", expectedToken)
 	t.Setenv("NOTIFY_SLACK_CHANNEL", expectedChannel)
-	t.Setenv("NOTIFY_SLACK_SNIPPET_CHANNEL", expectedSnippetChannel)
+	t.Setenv("NOTIFY_SLACK_CHANNEL_ID", expectedChannelID)
 	t.Setenv("NOTIFY_SLACK_USERNAME", expectedUsername)
 	t.Setenv("NOTIFY_SLACK_ICON_EMOJI", expectedIconEmoji)
 	t.Setenv("NOTIFY_SLACK_INTERVAL", expectedIntervalStr)
@@ -81,8 +95,8 @@ func TestLoadEnv(t *testing.T) {
 		t.Errorf("got %s, want %s", c.Channel, expectedChannel)
 	}
 
-	if c.SnippetChannel != expectedSnippetChannel {
-		t.Errorf("got %s, want %s", c.SnippetChannel, expectedSnippetChannel)
+	if c.ChannelID != expectedChannelID {
+		t.Errorf("got %s, want %s", c.ChannelID, expectedChannelID)
 	}
 
 	if c.Username != expectedUsername {
@@ -95,6 +109,35 @@ func TestLoadEnv(t *testing.T) {
 
 	if c.Duration != expectedInterval {
 		t.Errorf("got %+v, want %+v", c.Duration, expectedInterval)
+	}
+}
+
+func TestLoadEnv_Deprecated(t *testing.T) {
+	expectedSlackURL := "https://hooks.slack.com/aaaaa"
+	expectedToken := "xoxp-token"
+	expectedChannel := "#test"
+	expectedSnippetChannel := "#general"
+	expectedUsername := "deploy!"
+	expectedIconEmoji := ":rocket:"
+	expectedIntervalStr := "2s"
+
+	t.Setenv("NOTIFY_SLACK_WEBHOOK_URL", expectedSlackURL)
+	t.Setenv("NOTIFY_SLACK_TOKEN", expectedToken)
+	t.Setenv("NOTIFY_SLACK_CHANNEL", expectedChannel)
+	t.Setenv("NOTIFY_SLACK_SNIPPET_CHANNEL", expectedSnippetChannel)
+	t.Setenv("NOTIFY_SLACK_USERNAME", expectedUsername)
+	t.Setenv("NOTIFY_SLACK_ICON_EMOJI", expectedIconEmoji)
+	t.Setenv("NOTIFY_SLACK_INTERVAL", expectedIntervalStr)
+
+	c := NewConfig()
+	err := c.LoadEnv()
+	if err == nil {
+		t.Fatal("expected error, but got nil")
+	}
+
+	expected := "the NOTIFY_SLACK_SNIPPET_CHANNEL option is deprecated"
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("got %s, want %s", err.Error(), expected)
 	}
 }
 

--- a/internal/config/testdata/config_deprecated.toml
+++ b/internal/config/testdata/config_deprecated.toml
@@ -2,7 +2,7 @@
 url = "https://hooks.slack.com/aaaaa"
 token = "xoxp-token"
 channel = "#test"
-channel_id = "C12345678"
+snippet_channel = "#general"
 username = "deploy!"
 icon_emoji = ":rocket:"
 interval = "2s"

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -108,8 +109,13 @@ func TestPostText_Fail(t *testing.T) {
 	}
 
 	muxAPI.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		b, err := os.ReadFile("testdata/post_text_fail.html")
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		w.WriteHeader(http.StatusNotFound)
-		http.ServeFile(w, r, "testdata/post_text_fail.html")
+		w.Write(b)
 	})
 
 	c, err := NewClient(testAPIServer.URL, slog.New(slog.NewTextHandler(io.Discard, nil)))
@@ -136,17 +142,22 @@ func TestPostFile_Success(t *testing.T) {
 
 	slackToken := "slack-token"
 
-	param := &PostFileParam{
-		Channel:  "test-channel",
-		Content:  "testtesttest",
+	param := &GetUploadURLExternalResParam{
 		Filename: "test.txt",
+		Length:   100,
 	}
 
-	muxAPI.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	muxAPI.HandleFunc("/api/files.getUploadURLExternal", func(w http.ResponseWriter, r *http.Request) {
 		contentType := r.Header.Get("Content-Type")
 		expectedType := "application/x-www-form-urlencoded"
 		if contentType != expectedType {
 			t.Fatalf("Content-Type expected %s, but %s", expectedType, contentType)
+		}
+
+		authorization := r.Header.Get("Authorization")
+		expectedAuth := "Bearer " + slackToken
+		if authorization != expectedAuth {
+			t.Fatalf("Authorization expected %s, but %s", expectedAuth, authorization)
 		}
 
 		bodyBytes, err := io.ReadAll(r.Body)
@@ -161,51 +172,113 @@ func TestPostFile_Success(t *testing.T) {
 		}
 
 		expectedV := url.Values{}
-		expectedV.Set("token", slackToken)
-		expectedV.Set("content", param.Content)
 		expectedV.Set("filename", param.Filename)
-		expectedV.Set("channels", param.Channel)
+		expectedV.Set("length", strconv.Itoa(param.Length))
 
-		if !reflect.DeepEqual(actualV, expectedV) {
-			t.Fatalf("expected %q to equal %q", actualV, expectedV)
+		if diff := cmp.Diff(expectedV, actualV); diff != "" {
+			t.Errorf("unexpected diff: (-want +got):\n%s", diff)
 		}
 
-		http.ServeFile(w, r, "testdata/post_files_upload_ok.json")
+		http.ServeFile(w, r, "testdata/files_get_upload_url_external_ok.json")
 	})
 
-	defer SetSlackFilesUploadURL(testAPIServer.URL)()
+	defer SetFilesGetUploadURLExternalURL(testAPIServer.URL + "/api/files.getUploadURLExternal")()
 
 	c, err := NewClientForPostFile(slackToken, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = c.PostFile(context.Background(), param)
-
+	uploadURL, fileID, err := c.GetUploadURLExternalURL(context.Background(), param)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	expectedUploadURL := "https://files.slack.com/upload/v1/ABC123456"
+	if uploadURL != expectedUploadURL {
+		t.Fatalf("expected %q to equal %q", uploadURL, expectedUploadURL)
+	}
+
+	expectedFileID := "F123ABC456"
+	if fileID != expectedFileID {
+		t.Fatalf("expected %q to equal %q", fileID, expectedFileID)
+	}
 }
 
-func TestPostFile_Success_provideFiletype(t *testing.T) {
+func TestPostFile_FailCallFunc(t *testing.T) {
 	muxAPI := http.NewServeMux()
 	testAPIServer := httptest.NewServer(muxAPI)
 	defer testAPIServer.Close()
 
 	slackToken := "slack-token"
 
-	param := &PostFileParam{
-		Channel:  "test-channel",
-		Content:  "testtesttest",
-		Filename: "test.txt",
-		Filetype: "diff",
+	muxAPI.HandleFunc("/api/files.getUploadURLExternal", func(w http.ResponseWriter, r *http.Request) {
+		panic("unexpected call")
+	})
+
+	defer SetFilesGetUploadURLExternalURL(testAPIServer.URL + "/api/files.getUploadURLExternal")()
+
+	_, err := NewClientForPostFile("", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	expectedErrorPart := "provide Slack token"
+	if err == nil {
+		t.Fatal("expected error, but nothing was returned")
+	} else if !strings.Contains(err.Error(), expectedErrorPart) {
+		t.Fatalf("expected %q to contain %q", err.Error(), expectedErrorPart)
 	}
 
-	muxAPI.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	c, err := NewClientForPostFile(slackToken, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = c.GetUploadURLExternalURL(context.Background(), nil)
+	expectedErrorPart = "provide filename and length"
+	if err == nil {
+		t.Fatal("expected error, but nothing was returned")
+	} else if !strings.Contains(err.Error(), expectedErrorPart) {
+		t.Fatalf("expected %q to contain %q", err.Error(), expectedErrorPart)
+	}
+
+	_, _, err = c.GetUploadURLExternalURL(context.Background(), &GetUploadURLExternalResParam{})
+	expectedErrorPart = "provide filename"
+	if err == nil {
+		t.Fatal("expected error, but nothing was returned")
+	} else if !strings.Contains(err.Error(), expectedErrorPart) {
+		t.Fatalf("expected %q to contain %q", err.Error(), expectedErrorPart)
+	}
+
+	_, _, err = c.GetUploadURLExternalURL(context.Background(), &GetUploadURLExternalResParam{Filename: "test.txt"})
+	expectedErrorPart = "provide length"
+	if err == nil {
+		t.Fatal("expected error, but nothing was returned")
+	} else if !strings.Contains(err.Error(), expectedErrorPart) {
+		t.Fatalf("expected %q to contain %q", err.Error(), expectedErrorPart)
+	}
+}
+
+func TestPostFile_FailAPINotOK(t *testing.T) {
+	muxAPI := http.NewServeMux()
+	testAPIServer := httptest.NewServer(muxAPI)
+	defer testAPIServer.Close()
+
+	slackToken := "slack-token"
+
+	param := &GetUploadURLExternalResParam{
+		Filename: "test.txt",
+		Length:   100,
+	}
+
+	muxAPI.HandleFunc("/api/files.getUploadURLExternal", func(w http.ResponseWriter, r *http.Request) {
 		contentType := r.Header.Get("Content-Type")
 		expectedType := "application/x-www-form-urlencoded"
 		if contentType != expectedType {
 			t.Fatalf("Content-Type expected %s, but %s", expectedType, contentType)
+		}
+
+		authorization := r.Header.Get("Authorization")
+		expectedAuth := "Bearer " + slackToken
+		if authorization != expectedAuth {
+			t.Fatalf("Authorization expected %s, but %s", expectedAuth, authorization)
 		}
 
 		bodyBytes, err := io.ReadAll(r.Body)
@@ -220,139 +293,191 @@ func TestPostFile_Success_provideFiletype(t *testing.T) {
 		}
 
 		expectedV := url.Values{}
-		expectedV.Set("token", slackToken)
-		expectedV.Set("content", param.Content)
 		expectedV.Set("filename", param.Filename)
-		expectedV.Set("filetype", param.Filetype)
-		expectedV.Set("channels", param.Channel)
+		expectedV.Set("length", strconv.Itoa(param.Length))
 
-		if !reflect.DeepEqual(actualV, expectedV) {
-			t.Fatalf("expected %q to equal %q", actualV, expectedV)
+		if diff := cmp.Diff(expectedV, actualV); diff != "" {
+			t.Errorf("unexpected diff: (-want +got):\n%s", diff)
 		}
 
-		http.ServeFile(w, r, "testdata/post_files_upload_ok.json")
+		w.WriteHeader(http.StatusForbidden)
+		w.Header().Set("Content-Type", "application/json")
+
+		b, err := os.ReadFile("testdata/files_get_upload_url_external_fail.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		w.Write(b)
 	})
 
-	defer SetSlackFilesUploadURL(testAPIServer.URL)()
+	defer SetFilesGetUploadURLExternalURL(testAPIServer.URL + "/api/files.getUploadURLExternal")()
 
 	c, err := NewClientForPostFile(slackToken, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = c.PostFile(context.Background(), param)
+	_, _, err = c.GetUploadURLExternalURL(context.Background(), param)
 
-	if err != nil {
-		t.Fatal(err)
+	if err == nil {
+		t.Fatal("expected error, but nothing was returned")
+	} else {
+		expected := "status code: 403"
+		if !strings.Contains(err.Error(), expected) {
+			t.Errorf("expected %q to contain %q", err.Error(), expected)
+		}
+
+		expectedBodyPart := `"invalid_auth"`
+		if !strings.Contains(err.Error(), expectedBodyPart) {
+			t.Errorf("expected %q to contain %q", err.Error(), expectedBodyPart)
+		}
 	}
 }
 
-func TestPostFile_FailNotOk(t *testing.T) {
+func TestPostFile_FailAPIStatusOK(t *testing.T) {
 	muxAPI := http.NewServeMux()
 	testAPIServer := httptest.NewServer(muxAPI)
 	defer testAPIServer.Close()
 
 	slackToken := "slack-token"
 
-	param := &PostFileParam{
-		Channel:  "test-channel",
-		Content:  "testtesttest",
+	param := &GetUploadURLExternalResParam{
 		Filename: "test.txt",
+		Length:   100,
 	}
 
-	muxAPI.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		http.ServeFile(w, r, "testdata/post_files_upload_fail.json")
+	muxAPI.HandleFunc("/api/files.getUploadURLExternal", func(w http.ResponseWriter, r *http.Request) {
+		contentType := r.Header.Get("Content-Type")
+		expectedType := "application/x-www-form-urlencoded"
+		if contentType != expectedType {
+			t.Fatalf("Content-Type expected %s, but %s", expectedType, contentType)
+		}
+
+		authorization := r.Header.Get("Authorization")
+		expectedAuth := "Bearer " + slackToken
+		if authorization != expectedAuth {
+			t.Fatalf("Authorization expected %s, but %s", expectedAuth, authorization)
+		}
+
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Body.Close()
+
+		actualV, err := url.ParseQuery(string(bodyBytes))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expectedV := url.Values{}
+		expectedV.Set("filename", param.Filename)
+		expectedV.Set("length", strconv.Itoa(param.Length))
+
+		if diff := cmp.Diff(expectedV, actualV); diff != "" {
+			t.Errorf("unexpected diff: (-want +got):\n%s", diff)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		b, err := os.ReadFile("testdata/files_get_upload_url_external_fail_invalid_arguments.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		w.Write(b)
 	})
 
-	defer SetSlackFilesUploadURL(testAPIServer.URL)()
+	defer SetFilesGetUploadURLExternalURL(testAPIServer.URL + "/api/files.getUploadURLExternal")()
 
 	c, err := NewClientForPostFile(slackToken, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = c.PostFile(context.Background(), param)
+	_, _, err = c.GetUploadURLExternalURL(context.Background(), param)
 
 	if err == nil {
 		t.Fatal("expected error, but nothing was returned")
-	}
+	} else {
+		expected := "response has failed"
+		if !strings.Contains(err.Error(), expected) {
+			t.Errorf("expected %q to contain %q", err.Error(), expected)
+		}
 
-	expected := `response has failed; body: {"ok":false,"error":"invalid_auth"}`
-	if !strings.Contains(err.Error(), expected) {
-		t.Fatalf("expected %q to contain %q", err.Error(), expected)
+		expectedBodyPart := `"invalid_arguments"`
+		if !strings.Contains(err.Error(), expectedBodyPart) {
+			t.Errorf("expected %q to contain %q", err.Error(), expectedBodyPart)
+		}
 	}
 }
 
-func TestPostFile_FailNotResponseStatusCodeNotOK(t *testing.T) {
+func TestPostFile_FailBrokenJSON(t *testing.T) {
 	muxAPI := http.NewServeMux()
 	testAPIServer := httptest.NewServer(muxAPI)
 	defer testAPIServer.Close()
 
 	slackToken := "slack-token"
 
-	param := &PostFileParam{
-		Channel:  "test-channel",
-		Content:  "testtesttest",
+	param := &GetUploadURLExternalResParam{
 		Filename: "test.txt",
+		Length:   100,
 	}
 
-	muxAPI.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-		http.ServeFile(w, r, "testdata/post_files_upload_fail.json")
+	muxAPI.HandleFunc("/api/files.getUploadURLExternal", func(w http.ResponseWriter, r *http.Request) {
+		contentType := r.Header.Get("Content-Type")
+		expectedType := "application/x-www-form-urlencoded"
+		if contentType != expectedType {
+			t.Fatalf("Content-Type expected %s, but %s", expectedType, contentType)
+		}
+
+		authorization := r.Header.Get("Authorization")
+		expectedAuth := "Bearer " + slackToken
+		if authorization != expectedAuth {
+			t.Fatalf("Authorization expected %s, but %s", expectedAuth, authorization)
+		}
+
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Body.Close()
+
+		actualV, err := url.ParseQuery(string(bodyBytes))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expectedV := url.Values{}
+		expectedV.Set("filename", param.Filename)
+		expectedV.Set("length", strconv.Itoa(param.Length))
+
+		if diff := cmp.Diff(expectedV, actualV); diff != "" {
+			t.Errorf("unexpected diff: (-want +got):\n%s", diff)
+		}
+
+		w.Header().Set("Content-Type", "text/plain")
+
+		w.Write([]byte("this is not json"))
 	})
 
-	defer SetSlackFilesUploadURL(testAPIServer.URL)()
+	defer SetFilesGetUploadURLExternalURL(testAPIServer.URL + "/api/files.getUploadURLExternal")()
 
 	c, err := NewClientForPostFile(slackToken, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = c.PostFile(context.Background(), param)
+	_, _, err = c.GetUploadURLExternalURL(context.Background(), param)
 
 	if err == nil {
 		t.Fatal("expected error, but nothing was returned")
-	}
-
-	expected := `failed to read res.Body and the status code of the response from slack was not 200; body: {"ok":false,"error":"invalid_auth"}`
-	if !strings.Contains(err.Error(), expected) {
-		t.Fatalf("expected %q to contain %q", err.Error(), expected)
-	}
-}
-
-func TestPostFile_FailNotJSON(t *testing.T) {
-	muxAPI := http.NewServeMux()
-	testAPIServer := httptest.NewServer(muxAPI)
-	defer testAPIServer.Close()
-
-	slackToken := "slack-token"
-
-	param := &PostFileParam{
-		Channel:  "test-channel",
-		Content:  "testtesttest",
-		Filename: "test.txt",
-	}
-
-	muxAPI.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		http.ServeFile(w, r, "testdata/post_text_fail.html")
-	})
-
-	defer SetSlackFilesUploadURL(testAPIServer.URL)()
-
-	c, err := NewClientForPostFile(slackToken, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = c.PostFile(context.Background(), param)
-
-	if err == nil {
-		t.Fatal("expected error, but nothing was returned")
-	}
-
-	expected := `response returned from slack is not json`
-	if !strings.Contains(err.Error(), expected) {
-		t.Fatalf("expected %q to contain %q", err.Error(), expected)
+	} else {
+		expectedBodyPart := `this is not json`
+		if !strings.Contains(err.Error(), expectedBodyPart) {
+			t.Errorf("expected %q to contain %q", err.Error(), expectedBodyPart)
+		}
 	}
 }
 
@@ -488,12 +613,12 @@ func TestCompleteUploadExternal_Success(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	params := &CompleteUploadExternalParam{
+	param := &CompleteUploadExternalParam{
 		FileID:    "file-id",
 		Title:     "file-title",
 		ChannelID: "C0NF841BK",
 	}
-	err = c.CompleteUploadExternal(context.Background(), params)
+	err = c.CompleteUploadExternal(context.Background(), param)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/slack/export_test.go
+++ b/internal/slack/export_test.go
@@ -1,13 +1,5 @@
 package slack
 
-func SetSlackFilesUploadURL(u string) (resetFunc func()) {
-	var tmp string
-	tmp, slackFilesUploadURL = slackFilesUploadURL, u
-	return func() {
-		slackFilesUploadURL = tmp
-	}
-}
-
 func SetFilesGetUploadURLExternalURL(u string) (resetFunc func()) {
 	var tmp string
 	tmp, filesGetUploadURLExternalURL = filesGetUploadURLExternalURL, u


### PR DESCRIPTION
refs: #148 

This pull request introduces significant changes to the Slack API implementation, including updates to the file upload process and changes to the command line interface (CLI) and configuration files. The most important changes are the deprecation of the `files.upload` API, the introduction of new APIs for file uploads, and the replacement of the `channel` parameter with `channel-id` for file uploads.

API Changes:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R16): The `files.upload` API is now deprecated and replaced with `files.getUploadURLExternal` and `files.completeUploadExternal`. The `channel` parameter for file uploads has been replaced with `channel-id`. The `-filetype` option has been modified and replaced with `-snippet-type`.

CLI Changes:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL72-R82): The `channel` parameter in the CLI has been replaced with `channel-id`. The `-filetype` option has been marked as compatible and replaced with `-snippet-type`. The `uploadSnippet` function now requires a `channel-id` and `snippet-type` instead of a `channel` and `filetype`. [[1]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL72-R82) [[2]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL181-R183) [[3]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL219-R219) [[4]](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL257-R251)

Configuration Changes:

* `README.md`, `internal/config/config.go`, `internal/config/config_test.go`: The configuration files and tests have been updated to replace the `channel` parameter with `channel-id`. The `NOTIFY_SLACK_SNIPPET_CHANNEL` environment variable and the `snippet_channel` option in the TOML configuration file have been deprecated. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R59-R66) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R75-R76) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R101) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L106-R118) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L152-R158) [[6]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL19-R21) [[7]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL45-R51) [[8]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR79) [[9]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL112-R131) [[10]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L30-R33) [[11]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L61-R75) [[12]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L84-R99) [[13]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R115-R143)

Test Updates:

* `internal/cli/cli_test.go` and `internal/config/config_test.go`: The tests have been updated to reflect the changes in the CLI and configuration files. The `channel` parameter has been replaced with `channel-id` and the `-filetype` option has been replaced with `-snippet-type`. [[1]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddR12-R22) [[2]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL51-R68) [[3]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL90-R89) [[4]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL115-R126) [[5]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R6) [[6]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R49-R66) F93271deL112R99)