### PR TITLE
Update CHANGELOG for v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### Breaking Changes
 
-- **API Deprecation**: As per [Slack's latest API update](https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay), `files.upload` is now deprecated. We have updated our tool to use the new APIs, `files.getUploadURLExternal` and `files.completeUploadExternal`.
-- **Channel Specification**: It is no longer possible to specify a `channel` for file uploads. You must now use `channel-id`.
-- **Filetype Option Update**: The `-filetype` option has been modified. Please use `-snippet-type` instead for specifying the type of file when uploading to a snippet.
+* As per [Slack's latest API update](https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay), `files.upload` is now deprecated. We have updated our tool to use the new APIs, `files.getUploadURLExternal` and `files.completeUploadExternal`.
+* It is no longer possible to specify a `channel` for file uploads. You must now use `channel-id`.
+* The `snippet_channel` setting in TOML files and the `NOTIFY_SLACK_SNIPPET_CHANNEL` environment variable have been deprecated and are no longer supported.
+* The `-filetype` option has been modified. Please use `-snippet-type` instead for specifying the type of file when uploading to a snippet.
 
 ### Changed
 


### PR DESCRIPTION
This pull request includes significant changes to the `CHANGELOG.md` file, updating the documentation to reflect recent modifications to the Slack API and the corresponding adjustments in our tool. The main changes involve the deprecation of `files.upload` and the introduction of new APIs for file uploads, the replacement of `channel` with `channel-id` for specifying file upload destinations, the deprecation of the `snippet_channel` setting and `NOTIFY_SLACK_SNIPPET_CHANNEL` environment variable, and the modification of the `-filetype` option.

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL7-R10): Updated the "Breaking Changes" section to reflect the recent API changes from Slack. The `files.upload` method is now deprecated and replaced by `files.getUploadURLExternal` and `files.completeUploadExternal`. The `channel` parameter for file uploads has been replaced with `channel-id`. The `snippet_channel` setting in TOML files and the `NOTIFY_SLACK_SNIPPET_CHANNEL` environment variable are no longer supported. The `-filetype` option has been modified to `-snippet-type` for specifying the file type during uploads.