### PR TITLE
Update Slack API note in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ icon_emoji = ":rocket:"
 interval = "1s"
 ```
 
-Note:
+### Note
 
   * You will need to specify a url if you want to post messages to Slack as text
     * You can use the following options to customize your message when posting to Slack as text: `channel`, `username`, `icon_emoji`, and `interval`.
@@ -114,7 +114,7 @@ Note:
     * The `username` and `icon_emoji` options will be ignored when posting a file as a snippet to Slack.
     * For instructions on how to create a token, please see the next section.
     * You cannot specify a channel because the slack api support only the `channel_id`.
-    * If you don't specify `channel_id`, the file will be private. So, if you need to post a file public, you must specify `channel_id`.
+    * If you don't specify `channel_id`, the file will be private. So, **if you need to post a file public, you must specify `channel_id`**.
     * The Slack API can cause delays, so posting might take longer.
 
 ### How to create a token


### PR DESCRIPTION
This pull request includes minor modifications to the `README.md` file to improve the clarity of the documentation. The changes primarily focus on enhancing the readability of the notes section and emphasizing important information for users.

Key changes:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R107): The "Note" section has been reformatted for better readability and emphasis. The line "if you need to post a file public, you must specify `channel_id`" has been bolded to highlight its importance. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R107) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L117-R117)