### PR TITLE
Update go version to 1.22.2 and add go-cmp dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,11 @@
 module github.com/catatsuy/notify_slack
 
-go 1.19
+go 1.22.2
 
 require (
+	github.com/google/go-cmp v0.6.0
 	github.com/pelletier/go-toml/v2 v2.2.1
 	golang.org/x/term v0.19.0
 )
 
-require (
-	github.com/google/go-cmp v0.6.0 // indirect
-	golang.org/x/sys v0.19.0 // indirect
-)
+require golang.org/x/sys v0.19.0 // indirect


### PR DESCRIPTION
This pull request includes changes to the `go.mod` file to update the Go version and modify the dependencies. The Go version was updated from 1.19 to 1.22.2, and the dependency `github.com/google/go-cmp` was moved from an indirect requirement to a direct requirement. Additionally, the indirect requirement `golang.org/x/sys` was moved out of the separate indirect requirements group.

Here are the key changes:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R11): Updated the Go version from 1.19 to 1.22.2.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R11): Moved `github.com/google/go-cmp` from an indirect requirement to a direct requirement.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R11): Moved `golang.org/x/sys` out of the separate indirect requirements group.