### PR TITLE
Update go version to 1.22.2 and add go-cmp dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,11 @@
 module github.com/catatsuy/notify_slack
 
-go 1.19
+go 1.22.2
 
 require (
+	github.com/google/go-cmp v0.6.0
 	github.com/pelletier/go-toml/v2 v2.2.1
 	golang.org/x/term v0.19.0
 )
 
-require (
-	github.com/google/go-cmp v0.6.0 // indirect
-	golang.org/x/sys v0.19.0 // indirect
-)
+require golang.org/x/sys v0.19.0 // indirect


### PR DESCRIPTION
This pull request primarily updates the Go version and modifies the dependencies in the `go.mod` file. The Go version is updated from 1.19 to 1.22.2. The dependency `github.com/google/go-cmp` is moved from an indirect requirement to a direct one, while the indirect requirement for `golang.org/x/sys` is retained.

Here's the key change:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R11): Updated the Go version from 1.19 to 1.22.2. Moved `github.com/google/go-cmp` from an indirect requirement to a direct one, and retained `golang.org/x/sys` as an indirect requirement.