### PR TITLE
Update Go version requirement to 1.22.2 or higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Changed
 
-* update Go version
+* update Go version (require Go 1.22.2 or higher)
 * update dependent libraries
 * update README
 


### PR DESCRIPTION
This pull request includes a minor update to the `CHANGELOG.md` file. The change specifies the required Go version as 1.22.2 or higher.