### PR TITLE
Add new `-debug` option for development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * The `snippet_channel` setting in TOML files and the `NOTIFY_SLACK_SNIPPET_CHANNEL` environment variable have been deprecated and are no longer supported.
 * The `-filetype` option has been modified. Please use `-snippet-type` instead for specifying the type of file when uploading to a snippet.
 
+### Added
+
+- A new `-debug` option has been added for development.
+
 ### Changed
 
 * update Go version (require Go 1.22.2 or higher)


### PR DESCRIPTION
This pull request includes changes to the `CHANGELOG.md` file, primarily introducing a new `-debug` option for development purposes.

The key change is:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12-R15): A new `-debug` option has been added for development. This option will help developers in debugging the application.