### PR TITLE
Update NewCLI to receive isStdinTerminal parameter

### DIFF
--- a/cmd/notify_slack/main.go
+++ b/cmd/notify_slack/main.go
@@ -4,9 +4,10 @@ import (
 	"os"
 
 	"github.com/catatsuy/notify_slack/internal/cli"
+	"golang.org/x/term"
 )
 
 func main() {
-	c := cli.NewCLI(os.Stdout, os.Stderr, os.Stdin)
+	c := cli.NewCLI(os.Stdout, os.Stderr, os.Stdin, term.IsTerminal(int(os.Stdin.Fd())))
 	os.Exit(c.Run(os.Args))
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -16,7 +16,6 @@ import (
 	"github.com/catatsuy/notify_slack/internal/config"
 	"github.com/catatsuy/notify_slack/internal/slack"
 	"github.com/catatsuy/notify_slack/internal/throttle"
-	"golang.org/x/term"
 )
 
 var (
@@ -33,13 +32,15 @@ type CLI struct {
 	outStream, errStream io.Writer
 	inputStream          io.Reader
 
+	isStdinTerminal bool
+
 	sClient    slack.Slack
 	conf       *config.Config
 	appVersion string
 }
 
-func NewCLI(outStream, errStream io.Writer, inputStream io.Reader) *CLI {
-	return &CLI{appVersion: version(), outStream: outStream, errStream: errStream, inputStream: inputStream}
+func NewCLI(outStream, errStream io.Writer, inputStream io.Reader, isStdinTerminal bool) *CLI {
+	return &CLI{appVersion: version(), outStream: outStream, errStream: errStream, inputStream: inputStream, isStdinTerminal: isStdinTerminal}
 }
 
 func version() string {
@@ -113,7 +114,7 @@ func (c *CLI) Run(args []string) int {
 			fmt.Fprintln(c.errStream, "You cannot pass multiple files")
 			return ExitCodeParseFlagError
 		}
-	} else if term.IsTerminal(int(os.Stdin.Fd())) {
+	} else if c.isStdinTerminal {
 		fmt.Fprintln(c.errStream, "No input file specified")
 		return ExitCodeFail
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -28,7 +28,7 @@ func (c *fakeSlackClient) PostText(ctx context.Context, param *slack.PostTextPar
 
 func TestRun_versionFlg(t *testing.T) {
 	outStream, errStream, inputStream := new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)
-	cl := NewCLI(outStream, errStream, inputStream)
+	cl := NewCLI(outStream, errStream, inputStream, true)
 
 	args := strings.Split("notify_slack -version", " ")
 	status := cl.Run(args)


### PR DESCRIPTION
This pull request primarily focuses on modifying the terminal check in the `notify_slack` command-line interface (CLI). The changes include importing the `term` package in `main.go`, removing the import in `cli.go`, adding a new member to the `CLI` struct, and updating the `NewCLI` function and the terminal check in `Run` method. The test in `cli_test.go` was also updated to reflect these changes.

Here are the most significant changes:

Changes in `cmd/notify_slack/main.go`:

* Imported the `term` package and updated the `NewCLI` function call to include a terminal check. This change moves the terminal check from the `Run` method in `cli.go` to `main.go`.

Changes in `internal/cli/cli.go`:

* Removed the `term` package import. This import is no longer needed here as the terminal check has been moved to `main.go`.
* Added a new member `isStdinTerminal` to the `CLI` struct and updated the `NewCLI` function to accept this new member. This allows the terminal check result to be passed into the `CLI` struct.
* Updated the terminal check in the `Run` method to use the new `isStdinTerminal` member of the `CLI` struct instead of calling `term.IsTerminal`. This change reflects the new design where the terminal check is done in `main.go`.

Changes in `internal/cli/cli_test.go`:

* Updated the `NewCLI` function call in the test to include a boolean value for the new `isStdinTerminal` member. This ensures the test reflects the changes made to the `CLI` struct and `NewCLI` function.