### PR TITLE
Update Go version in GitHub Actions workflow to 1.22.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.22.4
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/release.yml` file. The `go-version` in the `Setup Go` job has been updated from a wildcard version `1.22.x` to a specific version `1.22.4`. This change ensures that the build process uses a consistent version of Go, improving the reliability of the build.