### PR TITLE
Add release.yml to renovate.json for golang version updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,16 @@
       "matchStrings": [
         "go-version-input: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
       ]
+    },
+    {
+      "fileMatch": [
+        ".github/workflows/release.yml"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang",
+      "matchStrings": [
+        "go-version: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+      ]
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
This pull request includes a change to the `renovate.json` file. The change adds a new section in the file that matches the `.github/workflows/release.yml` file and uses the `golang-version` data source template. The `depNameTemplate` is set to `golang` and the `matchStrings` is set to match the `go-version` followed by a version number.