### PR TITLE
update Go version from 1.22.2 to 1.23.0 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/catatsuy/notify_slack
 
-go 1.22.2
+go 1.23.0
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
This pull request updates the Go version in the `go.mod` file to ensure compatibility with the latest features and improvements.

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.22.2` to `1.23.0` to leverage new language features and improvements.

refs: https://go.dev/doc/go1.23#timer-changes