### PR TITLE
Use a shared context for uploading snippets and signal handling in CLI.

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -142,6 +142,8 @@ func (c *CLI) Run(args []string) int {
 		logger = slog.New(slog.NewTextHandler(c.errStream, nil))
 	}
 
+	ctx := context.Background()
+
 	if filename != "" || snippetMode {
 		if c.conf.Token == "" {
 			fmt.Fprintln(c.errStream, "must specify Slack token for uploading to snippet")
@@ -154,7 +156,7 @@ func (c *CLI) Run(args []string) int {
 			return ExitCodeFail
 		}
 
-		err := c.uploadSnippet(context.Background(), filename, uploadFilename, filetype)
+		err := c.uploadSnippet(ctx, filename, uploadFilename, filetype)
 		if err != nil {
 			fmt.Fprintln(c.errStream, err)
 			return ExitCodeFail
@@ -178,7 +180,7 @@ func (c *CLI) Run(args []string) int {
 
 	ex := throttle.NewExec(copyStdin)
 
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
 	channel := c.conf.Channel


### PR DESCRIPTION
This pull request includes changes to the `Run` method in `internal/cli/cli.go` to ensure a consistent context is used throughout the method. This helps maintain context propagation and improves the manageability of context-related operations.

Context management improvements:

* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eR145-R146): Introduced a `ctx` variable initialized with `context.Background()` at the beginning of the `Run` method to ensure a consistent context is used.
* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL157-R159): Updated the call to `uploadSnippet` to use the newly created `ctx` variable instead of creating a new context.
* [`internal/cli/cli.go`](diffhunk://#diff-223a11f450a34cbbac0fdfc3e1f9caeefd948071a628813149e6f8aa7c2bc15eL181-R183): Modified the `signal.NotifyContext` call to use the existing `ctx` variable, ensuring consistent context usage.