### PR TITLE
use t.Context() instead of context.Background() for test

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.23.x"]
+        go: ["1.24.x"]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/catatsuy/notify_slack
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -50,7 +50,7 @@ func TestUploadSnippet(t *testing.T) {
 	}
 
 	cl.conf.ChannelID = "C12345678"
-	err := cl.uploadSnippet(context.Background(), "testdata/nofile.txt", "", "")
+	err := cl.uploadSnippet(t.Context(), "testdata/nofile.txt", "", "")
 	want := "no such file or directory"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("error = %v; want %q", err, want)
@@ -72,7 +72,7 @@ func TestUploadSnippet(t *testing.T) {
 		},
 	}
 
-	err = cl.uploadSnippet(context.Background(), "testdata/upload.txt", "", "")
+	err = cl.uploadSnippet(t.Context(), "testdata/upload.txt", "", "")
 	if err != nil {
 		t.Errorf("expected nil; got %v", err)
 	}
@@ -93,7 +93,7 @@ func TestUploadSnippet(t *testing.T) {
 		},
 	}
 
-	err = cl.uploadSnippet(context.Background(), "testdata/upload.txt", "overwrite.txt", "")
+	err = cl.uploadSnippet(t.Context(), "testdata/upload.txt", "overwrite.txt", "")
 	if err != nil {
 		t.Errorf("expected nil; got %v", err)
 	}
@@ -123,7 +123,7 @@ func TestUploadSnippet(t *testing.T) {
 		},
 	}
 
-	err = cl.uploadSnippet(context.Background(), "testdata/upload.txt", "overwrite.txt", "diff")
+	err = cl.uploadSnippet(t.Context(), "testdata/upload.txt", "overwrite.txt", "diff")
 	if err != nil {
 		t.Errorf("expected nil; got %v", err)
 	}

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -1,7 +1,6 @@
 package slack_test
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -89,7 +88,7 @@ func TestPostText_Success(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = c.PostText(context.Background(), param)
+	err = c.PostText(t.Context(), param)
 
 	if err != nil {
 		t.Fatal(err)
@@ -123,7 +122,7 @@ func TestPostText_Fail(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = c.PostText(context.Background(), param)
+	err = c.PostText(t.Context(), param)
 
 	if err == nil {
 		t.Fatal("expected error, but nothing was returned")
@@ -189,7 +188,7 @@ func TestPostFile_Success(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	uploadURL, fileID, err := c.GetUploadURLExternalURL(context.Background(), param)
+	uploadURL, fileID, err := c.GetUploadURLExternalURL(t.Context(), param)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +230,7 @@ func TestPostFile_FailCallFunc(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, err = c.GetUploadURLExternalURL(context.Background(), nil)
+	_, _, err = c.GetUploadURLExternalURL(t.Context(), nil)
 	expectedErrorPart = "provide filename and length"
 	if err == nil {
 		t.Fatal("expected error, but nothing was returned")
@@ -239,7 +238,7 @@ func TestPostFile_FailCallFunc(t *testing.T) {
 		t.Fatalf("expected %q to contain %q", err.Error(), expectedErrorPart)
 	}
 
-	_, _, err = c.GetUploadURLExternalURL(context.Background(), &GetUploadURLExternalResParam{})
+	_, _, err = c.GetUploadURLExternalURL(t.Context(), &GetUploadURLExternalResParam{})
 	expectedErrorPart = "provide filename"
 	if err == nil {
 		t.Fatal("expected error, but nothing was returned")
@@ -247,7 +246,7 @@ func TestPostFile_FailCallFunc(t *testing.T) {
 		t.Fatalf("expected %q to contain %q", err.Error(), expectedErrorPart)
 	}
 
-	_, _, err = c.GetUploadURLExternalURL(context.Background(), &GetUploadURLExternalResParam{Filename: "test.txt"})
+	_, _, err = c.GetUploadURLExternalURL(t.Context(), &GetUploadURLExternalResParam{Filename: "test.txt"})
 	expectedErrorPart = "provide length"
 	if err == nil {
 		t.Fatal("expected error, but nothing was returned")
@@ -318,7 +317,7 @@ func TestPostFile_FailAPINotOK(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, err = c.GetUploadURLExternalURL(context.Background(), param)
+	_, _, err = c.GetUploadURLExternalURL(t.Context(), param)
 
 	if err == nil {
 		t.Fatal("expected error, but nothing was returned")
@@ -396,7 +395,7 @@ func TestPostFile_FailAPIStatusOK(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, err = c.GetUploadURLExternalURL(context.Background(), param)
+	_, _, err = c.GetUploadURLExternalURL(t.Context(), param)
 
 	if err == nil {
 		t.Fatal("expected error, but nothing was returned")
@@ -469,7 +468,7 @@ func TestPostFile_FailBrokenJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, err = c.GetUploadURLExternalURL(context.Background(), param)
+	_, _, err = c.GetUploadURLExternalURL(t.Context(), param)
 
 	if err == nil {
 		t.Fatal("expected error, but nothing was returned")
@@ -528,7 +527,7 @@ func TestUploadToURL_success(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = c.UploadToURL(context.Background(), "testdata/upload.txt", testAPIServer.URL, b)
+	err = c.UploadToURL(t.Context(), "testdata/upload.txt", testAPIServer.URL, b)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -553,7 +552,7 @@ func TestUploadToURL_fail(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = c.UploadToURL(context.Background(), "upload.txt", testAPIServer.URL, b)
+	err = c.UploadToURL(t.Context(), "upload.txt", testAPIServer.URL, b)
 	if err == nil {
 		t.Fatal("expected error, but nothing was returned")
 	}
@@ -618,7 +617,7 @@ func TestCompleteUploadExternal_Success(t *testing.T) {
 		Title:     "file-title",
 		ChannelID: "C0NF841BK",
 	}
-	err = c.CompleteUploadExternal(context.Background(), param)
+	err = c.CompleteUploadExternal(t.Context(), param)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/throttle/exec_test.go
+++ b/internal/throttle/exec_test.go
@@ -15,7 +15,7 @@ func TestRun_pipeClose(t *testing.T) {
 
 	ex := NewExec(pr)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	testC := make(chan time.Time)
 	count := 0
 	fc := make(chan struct{})
@@ -110,7 +110,7 @@ func TestRun_contextDone(t *testing.T) {
 
 	ex := NewExec(pr)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	testC := make(chan time.Time)
 	count := 0
 	fc := make(chan struct{})


### PR DESCRIPTION
This pull request includes several updates to the Go version and refactors tests to use the testing context. The most important changes include updating the Go version in the workflow and module files, and refactoring multiple test files to replace `context.Background()` with `t.Context()`.

### Go Version Update:
* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL9-R9): Updated the Go version from `1.23.x` to `1.24.x` in the CI workflow.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.23.0` to `1.24.0`.

### Test Refactoring:
* [`internal/cli/cli_test.go`](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL53-R53): Refactored the `TestUploadSnippet` function to use `t.Context()` instead of `context.Background()`. [[1]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL53-R53) [[2]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL75-R75) [[3]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL96-R96) [[4]](diffhunk://#diff-246ca99ef259ecd53ea453c8ddbb8893f3caf9cbc11a91bcc838daccd21c94ddL126-R126)
* [`internal/slack/client_test.go`](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL92-R91): Refactored multiple test functions (`TestPostText_Success`, `TestPostText_Fail`, `TestPostFile_Success`, `TestPostFile_FailCallFunc`, `TestPostFile_FailAPINotOK`, `TestPostFile_FailAPIStatusOK`, `TestPostFile_FailBrokenJSON`, `TestUploadToURL_success`, `TestUploadToURL_fail`, `TestCompleteUploadExternal_Success`) to use `t.Context()` instead of `context.Background()`. [[1]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL92-R91) [[2]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL126-R125) [[3]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL192-R191) [[4]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL234-R249) [[5]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL321-R320) [[6]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL399-R398) [[7]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL472-R471) [[8]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL531-R530) [[9]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL556-R555) [[10]](diffhunk://#diff-c09a18055362e712f5e7be2e1a0a904974c5217df3ecf1ecf36731e4eba6754eL621-R620)
* [`internal/throttle/exec_test.go`](diffhunk://#diff-2281b7d10d542ee07406bd08dac67e047566d8ec3e931e809c1f402328fc862bL18-R18): Refactored the `TestRun_pipeClose` and `TestRun_contextDone` functions to use `t.Context()` instead of `context.Background()`. [[1]](diffhunk://#diff-2281b7d10d542ee07406bd08dac67e047566d8ec3e931e809c1f402328fc862bL18-R18) [[2]](diffhunk://#diff-2281b7d10d542ee07406bd08dac67e047566d8ec3e931e809c1f402328fc862bL113-R113)