### PR TITLE
Update Go version to 1.24.0 in GitHub Actions workflow configuration.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,17 +2,12 @@ name: Go
 on: [push]
 jobs:
   test:
-    name: Build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: ["1.24.x"]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
-        id: go
+          go-version: 1.24.0
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Go. The most important changes include simplifying the workflow configuration by removing the matrix strategy and hardcoding the Go version.

Workflow configuration simplification:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL5-R10): Removed the matrix strategy and hardcoded the Go version to `1.24.0` instead of using a matrix variable.