### PR TITLE
Add golang version datasource configuration for go.yml workflow

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,16 @@
     },
     {
       "fileMatch": [
+        ".github/workflows/go.yml"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang",
+      "matchStrings": [
+        "go-version: (?<currentValue>[0-9]*.[0-9]*.[0-9]*)"
+      ]
+    },
+    {
+      "fileMatch": [
         ".github/workflows/release.yml"
       ],
       "datasourceTemplate": "golang-version",


### PR DESCRIPTION
This pull request includes an update to the `renovate.json` configuration file to ensure proper dependency management for Go versions in GitHub workflows.

Changes to dependency management:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R16-R25): Added a new configuration block to match and update Go versions specified in the `.github/workflows/go.yml` file. This includes setting the `datasourceTemplate` to "golang-version" and defining the `depNameTemplate` as "golang".