### PR TITLE
refactor: use t.Fatal

### DIFF
--- a/internal/throttle/exec_test.go
+++ b/internal/throttle/exec_test.go
@@ -10,9 +10,7 @@ import (
 
 func TestRun_pipeClose(t *testing.T) {
 	pr, pw := io.Pipe()
-
 	output := new(bytes.Buffer)
-
 	ex := NewExec(pr)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -26,16 +24,12 @@ func TestRun_pipeClose(t *testing.T) {
 			// to random fail from Go 1.12 or later
 			time.Sleep(2 * time.Millisecond)
 		}()
-
 		count++
-
 		output.WriteString(s)
-
 		return nil
 	}
 
 	doneCount := 0
-
 	doneCallback := func(ctx context.Context, s string) error {
 		defer func() {
 			// If goroutine is not used, tests cannot be run multiple times
@@ -59,27 +53,24 @@ func TestRun_pipeClose(t *testing.T) {
 
 	testC <- time.Time{}
 	<-fc
-
 	if count != 1 {
-		t.Error("the flushCallback function has not been called")
+		t.Fatal("the flushCallback function has not been called")
 	}
 
 	expected := []byte("abcd\nefgh\n")
 	pw.Write(expected)
 
-	if b := output.Bytes(); b != nil {
-		t.Errorf("will not be written if it is not flushed %s", b)
+	if b := output.Bytes(); len(b) != 0 {
+		t.Fatalf("will not be written if it is not flushed %q", b)
 	}
 
 	testC <- time.Time{}
 	<-fc
-
 	if count != 2 {
-		t.Errorf("the flushCallback function has not been called")
+		t.Fatalf("the flushCallback function has not been called")
 	}
-
 	if b := output.Bytes(); !bytes.Equal(b, expected) {
-		t.Errorf("It will be written %q; but %q", expected, b)
+		t.Fatalf("It will be written %q; but %q", expected, b)
 	}
 
 	output.Reset()
@@ -95,19 +86,16 @@ func TestRun_pipeClose(t *testing.T) {
 	<-fc
 
 	if doneCount != 1 {
-		t.Errorf("the doneCallback function has not been called")
+		t.Fatalf("the doneCallback function has not been called")
 	}
-
 	if b := output.Bytes(); !bytes.Equal(b, expected) {
-		t.Errorf("It will be written %q; but %q", expected, b)
+		t.Fatalf("It will be written %q; but %q", expected, b)
 	}
 }
 
 func TestRun_contextDone(t *testing.T) {
 	pr, pw := io.Pipe()
-
 	output := new(bytes.Buffer)
-
 	ex := NewExec(pr)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -121,16 +109,12 @@ func TestRun_contextDone(t *testing.T) {
 			// to random fail from Go 1.12 or later
 			time.Sleep(2 * time.Millisecond)
 		}()
-
 		count++
-
 		output.WriteString(s)
-
 		return nil
 	}
 
 	doneCount := 0
-
 	doneCallback := func(ctx context.Context, s string) error {
 		defer func() {
 			// If goroutine is not used, tests cannot be run multiple times
@@ -138,11 +122,8 @@ func TestRun_contextDone(t *testing.T) {
 				fc <- struct{}{}
 			}()
 		}()
-
 		doneCount++
-
 		output.WriteString(s)
-
 		return nil
 	}
 
@@ -154,27 +135,23 @@ func TestRun_contextDone(t *testing.T) {
 
 	testC <- time.Time{}
 	<-fc
-
 	if count != 1 {
-		t.Error("the flushCallback function has not been called")
+		t.Fatal("the flushCallback function has not been called")
 	}
 
 	expected := []byte("abcd\nefgh\n")
 	pw.Write(expected)
-
-	if b := output.Bytes(); b != nil {
-		t.Errorf("will not be written if it is not flushed %s", b)
+	if b := output.Bytes(); len(b) != 0 {
+		t.Fatalf("will not be written if it is not flushed %q", b)
 	}
 
 	testC <- time.Time{}
 	<-fc
-
 	if count != 2 {
-		t.Errorf("the flushCallback function has not been called")
+		t.Fatalf("the flushCallback function has not been called")
 	}
-
 	if b := output.Bytes(); !bytes.Equal(b, expected) {
-		t.Errorf("It will be written %q; but %q", expected, b)
+		t.Fatalf("It will be written %q; but %q", expected, b)
 	}
 
 	output.Reset()
@@ -184,14 +161,12 @@ func TestRun_contextDone(t *testing.T) {
 
 	cancel()
 	<-exitC
-
 	<-fc
 
 	if doneCount != 1 {
-		t.Errorf("the doneCallback function has not been called")
+		t.Fatalf("the doneCallback function has not been called")
 	}
-
 	if b := output.Bytes(); !bytes.Equal(b, expected) {
-		t.Errorf("It will be written %q; but %q", expected, b)
+		t.Fatalf("It will be written %q; but %q", expected, b)
 	}
 }


### PR DESCRIPTION
This pull request refactors the test assertions in `internal/throttle/exec_test.go` to use `t.Fatal` and `t.Fatalf` instead of `t.Error` and `t.Errorf`. This change ensures that test failures immediately stop the test, making debugging easier and preventing subsequent assertions from running after a failure.

**Test assertion improvements:**

* Replaced all uses of `t.Error`/`t.Errorf` with `t.Fatal`/`t.Fatalf` in both `TestRun_pipeClose` and `TestRun_contextDone` to ensure tests fail fast and provide clearer output on failure. [[1]](diffhunk://#diff-2281b7d10d542ee07406bd08dac67e047566d8ec3e931e809c1f402328fc862bL62-R73) [[2]](diffhunk://#diff-2281b7d10d542ee07406bd08dac67e047566d8ec3e931e809c1f402328fc862bL98-L110) [[3]](diffhunk://#diff-2281b7d10d542ee07406bd08dac67e047566d8ec3e931e809c1f402328fc862bL157-R154) [[4]](diffhunk://#diff-2281b7d10d542ee07406bd08dac67e047566d8ec3e931e809c1f402328fc862bL187-R170)

**Code cleanup:**

* Removed unnecessary blank lines and minor formatting adjustments for improved readability in the test functions. [[1]](diffhunk://#diff-2281b7d10d542ee07406bd08dac67e047566d8ec3e931e809c1f402328fc862bL13-L15) [[2]](diffhunk://#diff-2281b7d10d542ee07406bd08dac67e047566d8ec3e931e809c1f402328fc862bL29-L38) [[3]](diffhunk://#diff-2281b7d10d542ee07406bd08dac67e047566d8ec3e931e809c1f402328fc862bL124-L145)