### PR TITLE
Unblock ReadLine on context cancel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/catatsuy/notify_slack
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/internal/throttle/exec_test.go
+++ b/internal/throttle/exec_test.go
@@ -5,168 +5,171 @@ import (
 	"context"
 	"io"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
 func TestRun_pipeClose(t *testing.T) {
-	pr, pw := io.Pipe()
-	output := new(bytes.Buffer)
-	ex := NewExec(pr)
+	synctest.Test(t, func(t *testing.T) {
+		pr, pw := io.Pipe()
+		output := new(bytes.Buffer)
+		ex := NewExec(pr)
 
-	ctx, cancel := context.WithCancel(t.Context())
-	testC := make(chan time.Time)
-	count := 0
-	fc := make(chan struct{})
+		ctx, cancel := context.WithCancel(t.Context())
+		testC := make(chan time.Time)
+		count := 0
+		fc := make(chan struct{})
 
-	flushCallback := func(ctx context.Context, s string) error {
-		defer func() {
-			fc <- struct{}{}
-			// to random fail from Go 1.12 or later
-			time.Sleep(2 * time.Millisecond)
-		}()
-		count++
-		output.WriteString(s)
-		return nil
-	}
-
-	doneCount := 0
-	doneCallback := func(ctx context.Context, s string) error {
-		defer func() {
-			// If goroutine is not used, tests cannot be run multiple times
-			go func() {
+		flushCallback := func(ctx context.Context, s string) error {
+			defer func() {
 				fc <- struct{}{}
+				synctest.Wait()
 			}()
+			count++
+			output.WriteString(s)
+			return nil
+		}
+
+		doneCount := 0
+		doneCallback := func(ctx context.Context, s string) error {
+			defer func() {
+				// If goroutine is not used, tests cannot be run multiple times
+				go func() {
+					fc <- struct{}{}
+				}()
+			}()
+
+			doneCount++
+
+			output.WriteString(s)
+
+			return nil
+		}
+
+		exitC := make(chan struct{})
+		go func() {
+			ex.Start(ctx, testC, flushCallback, doneCallback)
+			close(exitC)
 		}()
 
-		doneCount++
+		testC <- time.Time{}
+		<-fc
+		if count != 1 {
+			t.Fatal("the flushCallback function has not been called")
+		}
 
-		output.WriteString(s)
+		expected := []byte("abcd\nefgh\n")
+		pw.Write(expected)
 
-		return nil
-	}
+		if b := output.Bytes(); len(b) != 0 {
+			t.Fatalf("will not be written if it is not flushed %q", b)
+		}
 
-	exitC := make(chan struct{})
-	go func() {
-		ex.Start(ctx, testC, flushCallback, doneCallback)
-		close(exitC)
-	}()
+		testC <- time.Time{}
+		<-fc
+		if count != 2 {
+			t.Fatalf("the flushCallback function has not been called")
+		}
+		if b := output.Bytes(); !bytes.Equal(b, expected) {
+			t.Fatalf("It will be written %q; but %q", expected, b)
+		}
 
-	testC <- time.Time{}
-	<-fc
-	if count != 1 {
-		t.Fatal("the flushCallback function has not been called")
-	}
+		output.Reset()
 
-	expected := []byte("abcd\nefgh\n")
-	pw.Write(expected)
+		expected = []byte("ijk\nlmn\n")
+		pw.Write(expected)
 
-	if b := output.Bytes(); len(b) != 0 {
-		t.Fatalf("will not be written if it is not flushed %q", b)
-	}
+		// do not panic
+		pw.Close()
+		<-exitC
 
-	testC <- time.Time{}
-	<-fc
-	if count != 2 {
-		t.Fatalf("the flushCallback function has not been called")
-	}
-	if b := output.Bytes(); !bytes.Equal(b, expected) {
-		t.Fatalf("It will be written %q; but %q", expected, b)
-	}
+		cancel()
+		<-fc
 
-	output.Reset()
-
-	expected = []byte("ijk\nlmn\n")
-	pw.Write(expected)
-
-	// do not panic
-	pw.Close()
-	<-exitC
-
-	cancel()
-	<-fc
-
-	if doneCount != 1 {
-		t.Fatalf("the doneCallback function has not been called")
-	}
-	if b := output.Bytes(); !bytes.Equal(b, expected) {
-		t.Fatalf("It will be written %q; but %q", expected, b)
-	}
+		if doneCount != 1 {
+			t.Fatalf("the doneCallback function has not been called")
+		}
+		if b := output.Bytes(); !bytes.Equal(b, expected) {
+			t.Fatalf("It will be written %q; but %q", expected, b)
+		}
+	})
 }
 
 func TestRun_contextDone(t *testing.T) {
-	pr, pw := io.Pipe()
-	output := new(bytes.Buffer)
-	ex := NewExec(pr)
+	synctest.Test(t, func(t *testing.T) {
+		pr, pw := io.Pipe()
+		output := new(bytes.Buffer)
+		ex := NewExec(pr)
 
-	ctx, cancel := context.WithCancel(t.Context())
-	testC := make(chan time.Time)
-	count := 0
-	fc := make(chan struct{})
+		ctx, cancel := context.WithCancel(t.Context())
+		testC := make(chan time.Time)
+		count := 0
+		fc := make(chan struct{})
 
-	flushCallback := func(ctx context.Context, s string) error {
-		defer func() {
-			fc <- struct{}{}
-			// to random fail from Go 1.12 or later
-			time.Sleep(2 * time.Millisecond)
-		}()
-		count++
-		output.WriteString(s)
-		return nil
-	}
-
-	doneCount := 0
-	doneCallback := func(ctx context.Context, s string) error {
-		defer func() {
-			// If goroutine is not used, tests cannot be run multiple times
-			go func() {
+		flushCallback := func(ctx context.Context, s string) error {
+			defer func() {
 				fc <- struct{}{}
+				synctest.Wait()
 			}()
+			count++
+			output.WriteString(s)
+			return nil
+		}
+
+		doneCount := 0
+		doneCallback := func(ctx context.Context, s string) error {
+			defer func() {
+				// If goroutine is not used, tests cannot be run multiple times
+				go func() {
+					fc <- struct{}{}
+				}()
+			}()
+			doneCount++
+			output.WriteString(s)
+			return nil
+		}
+
+		exitC := make(chan struct{})
+		go func() {
+			ex.Start(ctx, testC, flushCallback, doneCallback)
+			close(exitC)
 		}()
-		doneCount++
-		output.WriteString(s)
-		return nil
-	}
 
-	exitC := make(chan struct{})
-	go func() {
-		ex.Start(ctx, testC, flushCallback, doneCallback)
-		close(exitC)
-	}()
+		testC <- time.Time{}
+		<-fc
+		if count != 1 {
+			t.Fatal("the flushCallback function has not been called")
+		}
 
-	testC <- time.Time{}
-	<-fc
-	if count != 1 {
-		t.Fatal("the flushCallback function has not been called")
-	}
+		expected := []byte("abcd\nefgh\n")
+		pw.Write(expected)
+		if b := output.Bytes(); len(b) != 0 {
+			t.Fatalf("will not be written if it is not flushed %q", b)
+		}
 
-	expected := []byte("abcd\nefgh\n")
-	pw.Write(expected)
-	if b := output.Bytes(); len(b) != 0 {
-		t.Fatalf("will not be written if it is not flushed %q", b)
-	}
+		testC <- time.Time{}
+		<-fc
+		if count != 2 {
+			t.Fatalf("the flushCallback function has not been called")
+		}
+		if b := output.Bytes(); !bytes.Equal(b, expected) {
+			t.Fatalf("It will be written %q; but %q", expected, b)
+		}
 
-	testC <- time.Time{}
-	<-fc
-	if count != 2 {
-		t.Fatalf("the flushCallback function has not been called")
-	}
-	if b := output.Bytes(); !bytes.Equal(b, expected) {
-		t.Fatalf("It will be written %q; but %q", expected, b)
-	}
+		output.Reset()
 
-	output.Reset()
+		expected = []byte("ijk\nlmn\n")
+		pw.Write(expected)
 
-	expected = []byte("ijk\nlmn\n")
-	pw.Write(expected)
+		cancel()
+		<-exitC
+		<-fc
 
-	cancel()
-	<-exitC
-	<-fc
-
-	if doneCount != 1 {
-		t.Fatalf("the doneCallback function has not been called")
-	}
-	if b := output.Bytes(); !bytes.Equal(b, expected) {
-		t.Fatalf("It will be written %q; but %q", expected, b)
-	}
+		if doneCount != 1 {
+			t.Fatalf("the doneCallback function has not been called")
+		}
+		if b := output.Bytes(); !bytes.Equal(b, expected) {
+			t.Fatalf("It will be written %q; but %q", expected, b)
+		}
+	})
 }


### PR DESCRIPTION
- Keep refs to io.ReadCloser/*io.PipeReader in Exec.
- On ctx.Done(), close the reader (CloseWithError for PipeReader).
- Add cancelReader and call it before doneCallback.
- Replace time.Sleep with synctest.Wait and wrap tests with synctest.Test.

Prevents hangs/leaks on blocked ReadLine and removes test flakiness.

This pull request improves the handling of context cancellation and resource cleanup in the `Exec` struct, especially when working with pipe readers. It also updates the related tests to be more reliable and deterministic by using the `synctest` package.

**Resource management and context cancellation:**
- Enhanced the `Exec` struct to track `io.ReadCloser` and `io.PipeReader` instances, allowing for proper closure and cleanup when context is cancelled. The new `cancelReader` method ensures that blocked reads are unblocked by closing the underlying reader appropriately. [[1]](diffhunk://#diff-d6a9e728539756486b18385ec930dc52088f9a3d10bf7568eb90ba523432b154R15-R37) [[2]](diffhunk://#diff-d6a9e728539756486b18385ec930dc52088f9a3d10bf7568eb90ba523432b154R108-R120) [[3]](diffhunk://#diff-d6a9e728539756486b18385ec930dc52088f9a3d10bf7568eb90ba523432b154R91)

**Testing improvements:**
- Updated tests in `exec_test.go` to use the `synctest` package for deterministic synchronization instead of relying on arbitrary sleeps, making the tests more robust and less flaky. [[1]](diffhunk://#diff-2281b7d10d542ee07406bd08dac67e047566d8ec3e931e809c1f402328fc862bR8-R13) [[2]](diffhunk://#diff-2281b7d10d542ee07406bd08dac67e047566d8ec3e931e809c1f402328fc862bL24-R26) [[3]](diffhunk://#diff-2281b7d10d542ee07406bd08dac67e047566d8ec3e931e809c1f402328fc862bL42-L44) [[4]](diffhunk://#diff-2281b7d10d542ee07406bd08dac67e047566d8ec3e931e809c1f402328fc862bR93-R97) [[5]](diffhunk://#diff-2281b7d10d542ee07406bd08dac67e047566d8ec3e931e809c1f402328fc862bL109-R110) [[6]](diffhunk://#diff-2281b7d10d542ee07406bd08dac67e047566d8ec3e931e809c1f402328fc862bR172)