### PR TITLE
refactor CLI Run to use structured flag parsing and separate modes

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -55,21 +55,71 @@ func version() string {
 	return info.Main.Version
 }
 
-func (c *CLI) Run(args []string) int {
-	var (
-		version        bool
-		tomlFile       string
-		uploadFilename string
-		filetype       string
-		snippetMode    bool
-		debugMode      bool
-	)
+type cliOptions struct {
+	version        bool
+	tomlFile       string
+	uploadFilename string
+	filetype       string
+	snippetMode    bool
+	debugMode      bool
+	filename       string
+}
 
+func (c *CLI) Run(args []string) int {
+	opts, err := c.parseFlags(args)
+	if err != nil {
+		return ExitCodeParseFlagError
+	}
+
+	if opts.version {
+		c.printVersion()
+		return ExitCodeOK
+	}
+
+	if err := c.loadConfiguration(opts.tomlFile); err != nil {
+		fmt.Fprintln(c.errStream, err)
+		return ExitCodeFail
+	}
+
+	logger := c.createLogger(opts.debugMode)
+	ctx := context.Background()
+
+	if opts.filename != "" || opts.snippetMode {
+		return c.handleSnippetMode(ctx, opts, logger)
+	}
+
+	return c.handleTextMode(ctx, logger)
+}
+
+func (c *CLI) parseFlags(args []string) (*cliOptions, error) {
+	opts := &cliOptions{}
 	c.conf = config.NewConfig()
 
 	flags := flag.NewFlagSet("notify_slack", flag.ContinueOnError)
 	flags.SetOutput(c.errStream)
 
+	// Set up all flags
+	c.setupFlags(flags, opts)
+
+	if err := flags.Parse(args[1:]); err != nil {
+		return nil, err
+	}
+
+	// Check version flag first - it doesn't need file arguments
+	if opts.version {
+		return opts, nil
+	}
+
+	// Process remaining arguments
+	argv := flags.Args()
+	if err := c.processArguments(argv, opts, flags); err != nil {
+		return nil, err
+	}
+
+	return opts, nil
+}
+
+func (c *CLI) setupFlags(flags *flag.FlagSet, opts *cliOptions) {
 	flags.StringVar(&c.conf.Channel, "channel", "", "specify channel (unavailable for new Incoming Webhooks)")
 	flags.StringVar(&c.conf.ChannelID, "channel-id", "", "specify channel id (for uploading a file)")
 	flags.StringVar(&c.conf.SlackURL, "slack-url", "", "slack url (Incoming Webhooks URL)")
@@ -77,116 +127,102 @@ func (c *CLI) Run(args []string) int {
 	flags.StringVar(&c.conf.Username, "username", "", "specify username (unavailable for new Incoming Webhooks)")
 	flags.StringVar(&c.conf.IconEmoji, "icon-emoji", "", "specify icon emoji (unavailable for new Incoming Webhooks)")
 	flags.DurationVar(&c.conf.Duration, "interval", time.Second, "interval")
-	flags.StringVar(&tomlFile, "c", "", "config file name")
-	flags.StringVar(&uploadFilename, "filename", "", "specify a file name (for uploading to snippet)")
-	flags.StringVar(&filetype, "filetype", "", "[compatible] specify a filetype for uploading to snippet. This option is maintained for compatibility. Please use -snippet-type instead.")
-	flags.StringVar(&filetype, "snippet-type", "", "specify a snippet_type (for uploading to snippet)")
+	flags.StringVar(&opts.tomlFile, "c", "", "config file name")
+	flags.StringVar(&opts.uploadFilename, "filename", "", "specify a file name (for uploading to snippet)")
+	flags.StringVar(&opts.filetype, "filetype", "", "[compatible] specify a filetype for uploading to snippet. This option is maintained for compatibility. Please use -snippet-type instead.")
+	flags.StringVar(&opts.filetype, "snippet-type", "", "specify a snippet_type (for uploading to snippet)")
+	flags.BoolVar(&opts.snippetMode, "snippet", false, "switch to snippet uploading mode")
+	flags.BoolVar(&opts.debugMode, "debug", false, "debug mode (for developers)")
+	flags.BoolVar(&opts.version, "version", false, "Print version information and quit")
+}
 
-	flags.BoolVar(&snippetMode, "snippet", false, "switch to snippet uploading mode")
-
-	flags.BoolVar(&debugMode, "debug", false, "debug mode (for developers)")
-
-	flags.BoolVar(&version, "version", false, "Print version information and quit")
-
-	err := flags.Parse(args[1:])
-	if err != nil {
-		return ExitCodeParseFlagError
-	}
-
-	if version {
-		fmt.Fprintf(c.errStream, "notify_slack version %s; %s\n", c.appVersion, runtime.Version())
-		return ExitCodeOK
-	}
-
-	argv := flags.Args()
-	filename := ""
+func (c *CLI) processArguments(argv []string, opts *cliOptions, flags *flag.FlagSet) error {
 	if len(argv) == 1 {
-		filename = argv[0]
+		opts.filename = argv[0]
 	} else if len(argv) > 1 {
-		filename = argv[0]
-		err = flags.Parse(argv[1:])
-		if err != nil {
-			return ExitCodeParseFlagError
+		opts.filename = argv[0]
+		if err := flags.Parse(argv[1:]); err != nil {
+			return err
 		}
-
 		argv = flags.Args()
 		if len(argv) > 0 {
 			fmt.Fprintln(c.errStream, "You cannot pass multiple files")
-			return ExitCodeParseFlagError
+			return fmt.Errorf("multiple files specified")
 		}
 	} else if c.isStdinTerminal {
 		fmt.Fprintln(c.errStream, "No input file specified")
+		return fmt.Errorf("no input file specified")
+	}
+	return nil
+}
+
+func (c *CLI) printVersion() {
+	fmt.Fprintf(c.errStream, "notify_slack version %s; %s\n", c.appVersion, runtime.Version())
+}
+
+func (c *CLI) loadConfiguration(tomlFile string) error {
+	tomlFile = config.LoadTOMLFilename(tomlFile)
+	if tomlFile != "" {
+		if err := c.conf.LoadTOML(tomlFile); err != nil {
+			return err
+		}
+	}
+	return c.conf.LoadEnv()
+}
+
+func (c *CLI) createLogger(debugMode bool) *slog.Logger {
+	if debugMode {
+		return slog.New(slog.NewTextHandler(c.errStream, &slog.HandlerOptions{AddSource: true, Level: slog.LevelDebug}))
+	}
+	return slog.New(slog.NewTextHandler(c.errStream, nil))
+}
+
+func (c *CLI) handleSnippetMode(ctx context.Context, opts *cliOptions, logger *slog.Logger) int {
+	if c.conf.Token == "" {
+		fmt.Fprintln(c.errStream, "must specify Slack token for uploading to snippet")
 		return ExitCodeFail
 	}
 
-	tomlFile = config.LoadTOMLFilename(tomlFile)
-
-	if tomlFile != "" {
-		err := c.conf.LoadTOML(tomlFile)
-		if err != nil {
-			fmt.Fprintln(c.errStream, err)
-			return ExitCodeFail
-		}
-	}
-
-	err = c.conf.LoadEnv()
+	var err error
+	c.sClient, err = slack.NewClientForPostFile(c.conf.Token, logger)
 	if err != nil {
 		fmt.Fprintln(c.errStream, err)
 		return ExitCodeFail
 	}
 
-	var logger *slog.Logger
-	if debugMode {
-		logger = slog.New(slog.NewTextHandler(c.errStream, &slog.HandlerOptions{AddSource: true, Level: slog.LevelDebug}))
-	} else {
-		logger = slog.New(slog.NewTextHandler(c.errStream, nil))
+	if err := c.uploadSnippet(ctx, opts.filename, opts.uploadFilename, opts.filetype); err != nil {
+		fmt.Fprintln(c.errStream, err)
+		return ExitCodeFail
 	}
 
-	ctx := context.Background()
+	return ExitCodeOK
+}
 
-	if filename != "" || snippetMode {
-		if c.conf.Token == "" {
-			fmt.Fprintln(c.errStream, "must specify Slack token for uploading to snippet")
-			return ExitCodeFail
-		}
-
-		c.sClient, err = slack.NewClientForPostFile(c.conf.Token, logger)
-		if err != nil {
-			fmt.Fprintln(c.errStream, err)
-			return ExitCodeFail
-		}
-
-		err := c.uploadSnippet(ctx, filename, uploadFilename, filetype)
-		if err != nil {
-			fmt.Fprintln(c.errStream, err)
-			return ExitCodeFail
-		}
-
-		return ExitCodeOK
-	}
-
+func (c *CLI) handleTextMode(ctx context.Context, logger *slog.Logger) int {
 	if c.conf.SlackURL == "" {
 		fmt.Fprintln(c.errStream, "must specify Slack URL")
 		return ExitCodeFail
 	}
 
+	var err error
 	c.sClient, err = slack.NewClient(c.conf.SlackURL, logger)
 	if err != nil {
 		fmt.Fprintln(c.errStream, err)
 		return ExitCodeFail
 	}
 
-	copyStdin := io.TeeReader(c.inputStream, c.outStream)
+	return c.streamToSlack(ctx)
+}
 
+func (c *CLI) streamToSlack(ctx context.Context) int {
+	copyStdin := io.TeeReader(c.inputStream, c.outStream)
 	ex := throttle.NewExec(copyStdin)
 
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
-	channel := c.conf.Channel
-
 	param := &slack.PostTextParam{
-		Channel:   channel,
+		Channel:   c.conf.Channel,
 		Username:  c.conf.Username,
 		IconEmoji: c.conf.IconEmoji,
 	}
@@ -197,15 +233,12 @@ func (c *CLI) Run(args []string) int {
 	}
 
 	done := make(chan struct{})
-
 	doneCallback := func(ctx context.Context, output string) error {
 		defer func() {
-			// If goroutine is not used, it will not exit when the pipe is closed
 			go func() {
 				done <- struct{}{}
 			}()
 		}()
-
 		return flushCallback(context.WithoutCancel(ctx), output)
 	}
 


### PR DESCRIPTION
This pull request refactors the `CLI` implementation in `internal/cli/cli.go` to improve maintainability and clarity by modularizing the flag parsing, configuration loading, and execution logic. The main `Run` method is simplified, and new helper methods and a struct are introduced to encapsulate CLI options and logic. This makes the codebase easier to understand, extend, and test.

Key changes include:

**Refactoring and Code Structure:**
* Introduced a new `cliOptions` struct to encapsulate all CLI flag values, replacing multiple local variables and streamlining option handling.
* Split the monolithic `Run` method into smaller, focused helper methods: `parseFlags`, `setupFlags`, `processArguments`, `printVersion`, `loadConfiguration`, `createLogger`, `handleSnippetMode`, `handleTextMode`, and `streamToSlack`. This modularization improves readability and testability.
* Moved flag setup and parsing logic into `setupFlags` and `parseFlags`, separating concerns and reducing duplication.

**Error Handling and User Feedback:**
* Improved error handling for argument parsing, configuration loading, and input validation, providing clearer error messages for cases like multiple files or missing input.

**Behavioral Consistency:**
* Ensured the `--version` flag is handled early and independently of other options, and refactored version printing into its own method.

**Minor Improvements:**
* Cleaned up unnecessary variable assignments and improved the structure of the `doneCallback` goroutine for better clarity.