### PR TITLE
Use http.MethodPost constant instead of string literal

### DIFF
--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -116,7 +116,7 @@ func (c *Client) PostText(ctx context.Context, param *PostTextParam) error {
 
 	b, _ := json.Marshal(param)
 
-	req, err := c.newRequest(ctx, "POST", bytes.NewBuffer(b))
+	req, err := c.newRequest(ctx, http.MethodPost, bytes.NewBuffer(b))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This pull request makes a minor update to the `PostText` method in the Slack client, improving code clarity by replacing the hardcoded HTTP method string with the `http.MethodPost` constant.

* Refactored the `PostText` method in `client.go` to use `http.MethodPost` instead of the string "POST" for the HTTP method argument.