### PR TITLE
update random import to rand/v2 and fix sleep duration calculation

### DIFF
--- a/cmd/output/main.go
+++ b/cmd/output/main.go
@@ -3,19 +3,18 @@ package main
 import (
 	"flag"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"time"
 )
 
 func init() {
 	flag.Parse()
-	rand.Seed(time.Now().Unix())
 }
 
 func main() {
 	for i := 0; i < 1000; i++ {
 		fmt.Printf("Welcome %d times\n", i)
 		// sleep 10ms-30ms
-		time.Sleep((time.Duration)(rand.Intn(3)+1) * 10 * time.Millisecond)
+		time.Sleep((time.Duration)(rand.IntN(3)+1) * 10 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
This pull request updates the random number generation in `cmd/output/main.go` to use the newer `math/rand/v2` package and its API. The seeding logic has also been removed, as the new API handles seeding automatically.

**Dependency and API updates:**

* Switched import from `math/rand` to `math/rand/v2` and updated usage from `rand.Intn` to `rand.IntN`, reflecting the new package's API.

**Code cleanup:**

* Removed manual seeding of the random number generator, as `math/rand/v2` now manages this internally.