### PR TITLE
Add explicit contents permissions to GitHub workflow files for security

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,9 @@
 name: Go
 on: [push]
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   govulncheck_job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates GitHub Actions workflow configuration files to explicitly set permissions for better security and access control. The most important changes are the addition of `permissions` blocks to each workflow, specifying the minimum required access for each job.

**Workflow permissions updates:**

* Added `permissions: contents: read` to `.github/workflows/go.yml` to restrict the workflow's access to repository contents to read-only.
* Added `permissions: contents: write` to `.github/workflows/release.yml` to allow the release workflow to write to repository contents, which is necessary for publishing releases.
* Added `permissions: contents: read` to `.github/workflows/security.yml` to restrict the security workflow's access to repository contents to read-only.