### PR TITLE
fix test synchronization by adjusting synctest.Wait calls

### DIFF
--- a/internal/throttle/exec_test.go
+++ b/internal/throttle/exec_test.go
@@ -23,7 +23,6 @@ func TestRun_pipeClose(t *testing.T) {
 		flushCallback := func(ctx context.Context, s string) error {
 			defer func() {
 				fc <- struct{}{}
-				synctest.Wait()
 			}()
 			count++
 			output.WriteString(s)
@@ -60,6 +59,7 @@ func TestRun_pipeClose(t *testing.T) {
 
 		expected := []byte("abcd\nefgh\n")
 		pw.Write(expected)
+		synctest.Wait()
 
 		if b := output.Bytes(); len(b) != 0 {
 			t.Fatalf("will not be written if it is not flushed %q", b)
@@ -109,7 +109,6 @@ func TestRun_contextDone(t *testing.T) {
 		flushCallback := func(ctx context.Context, s string) error {
 			defer func() {
 				fc <- struct{}{}
-				synctest.Wait()
 			}()
 			count++
 			output.WriteString(s)
@@ -143,6 +142,7 @@ func TestRun_contextDone(t *testing.T) {
 
 		expected := []byte("abcd\nefgh\n")
 		pw.Write(expected)
+		synctest.Wait()
 		if b := output.Bytes(); len(b) != 0 {
 			t.Fatalf("will not be written if it is not flushed %q", b)
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test synchronization for pipe-close and context-cancellation scenarios, helping ensure more reliable and deterministic test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->